### PR TITLE
Fix create_organization! to pass all attributes

### DIFF
--- a/lib/organizations/models/concerns/has_organizations.rb
+++ b/lib/organizations/models/concerns/has_organizations.rb
@@ -369,11 +369,18 @@ module Organizations
 
           # Creates a new organization with this user as owner
           # Sets the new organization as the current organization
-          # @param name_or_options [String, Hash] Organization name or options hash
+          # @param name_or_attributes [String, Hash] Organization name or attributes hash
           # @return [Organizations::Organization]
           # @raise [OrganizationLimitReached] if user has reached their organization limit
-          def create_organization!(name_or_options)
-            name = name_or_options.is_a?(Hash) ? name_or_options[:name] : name_or_options
+          #
+          # @example With just a name
+          #   user.create_organization!("Acme Corp")
+          #
+          # @example With additional attributes
+          #   user.create_organization!(name: "Acme Corp", support_email: "support@acme.com")
+          #
+          def create_organization!(name_or_attributes)
+            attributes = name_or_attributes.is_a?(Hash) ? name_or_attributes : { name: name_or_attributes }
 
             # Check max organizations limit
             settings = self.class.organization_settings
@@ -384,7 +391,7 @@ module Organizations
 
             org = nil
             ActiveRecord::Base.transaction do
-              org = Organizations::Organization.create!(name: name)
+              org = Organizations::Organization.create!(attributes)
 
               Organizations::Membership.create!(
                 user: self,

--- a/test/concerns/has_organizations_test.rb
+++ b/test/concerns/has_organizations_test.rb
@@ -581,6 +581,19 @@ module Organizations
       assert org.persisted?
     end
 
+    test "create_organization! with additional attributes hash" do
+      user = create_user!
+      # Passing additional attributes beyond just name should work
+      org = user.create_organization!(name: "Extended Org", metadata: { "custom" => "value" })
+
+      assert_equal "Extended Org", org.name
+      assert org.persisted?
+      assert_equal :owner, user.role_in(org)
+      # Metadata column is text in test schema, verify the value was passed through
+      assert_includes org.metadata, "custom"
+      assert_includes org.metadata, "value"
+    end
+
     test "create_organization! sets current_organization context" do
       user = create_user!
       org = user.create_organization!("Context Org")


### PR DESCRIPTION
## Summary

- Fixed `create_organization!` to pass all attributes from the hash to `Organization.create!`, not just the `name`
- Added test for passing additional attributes

## Problem

Previously, `create_organization!` only extracted the `name` from the options hash:

```ruby
name = name_or_options.is_a?(Hash) ? name_or_options[:name] : name_or_options
org = Organizations::Organization.create!(name: name)
```

This made it impossible to use when the Organization model has additional required validations. For example, if you follow the README's guidance to add custom validations:

```ruby
Organizations::Organization.class_eval do
  validates :support_email, presence: true
end
```

Then `create_organization!` would fail because it doesn't pass `support_email` to `create!`.

## Solution

Pass all attributes from the hash:

```ruby
attributes = name_or_attributes.is_a?(Hash) ? name_or_attributes : { name: name_or_attributes }
org = Organizations::Organization.create!(attributes)
```

Now users can pass any attributes their Organization model needs:

```ruby
user.create_organization!(name: "Acme", support_email: "support@acme.com")
```

## Test plan

- [x] Added test for `create_organization!` with additional attributes
- [x] All 753 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)