### PR TITLE
Add public_controller config for public routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,14 @@ Organizations.configure do |config|
   # Where to redirect when user has no organization
   config.redirect_path_when_no_organization = "/organizations/new"
 
+  # === Engine Controllers ===
+  # Base controller for authenticated routes (default: ::ApplicationController)
+  config.parent_controller = "::ApplicationController"
+
+  # Base controller for public routes like invitation acceptance (default: ActionController::Base)
+  # Use this to avoid inheriting host app filters that enforce authentication
+  config.public_controller = "ActionController::Base"
+
   # === Handlers ===
   # Called when authorization fails
   config.on_unauthorized do |context|

--- a/app/controllers/organizations/invitations_controller.rb
+++ b/app/controllers/organizations/invitations_controller.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
 module Organizations
-  # Controller for handling organization invitations.
-  # Supports both viewing/accepting invitations via token (public) and
-  # managing invitations within an organization (requires admin).
+  # Controller for managing organization invitations.
+  # Requires admin/invite_members permission for all actions.
+  #
+  # Note: Public invitation routes (show/accept) are handled by
+  # PublicInvitationsController to avoid host app authentication filters.
   #
   class InvitationsController < ApplicationController
-    # Skip authentication for public invitation routes
-    skip_before_action :authenticate_organizations_user!, only: [:show, :accept]
-
-    # Require invitation permission for invitation management
-    before_action -> { require_organization_permission_to!(:invite_members) }, only: [:index, :new, :create, :destroy, :resend]
-    before_action :set_invitation_by_token, only: [:show, :accept]
-    before_action :set_invitation_by_id, only: [:destroy, :resend]
+    before_action -> { require_organization_permission_to!(:invite_members) }
+    before_action :set_invitation, only: [:destroy, :resend]
 
     # GET /invitations
     # List all invitations for the current organization
@@ -62,71 +59,6 @@ module Organizations
       end
     end
 
-    # GET /invitations/:token
-    # View invitation details (public route)
-    def show
-      @user_exists = user_exists_for_invitation?
-      @user_is_logged_in = current_user.present?
-      @user_email_matches = @user_is_logged_in && current_user.email.downcase == @invitation.email.downcase
-
-      respond_to do |format|
-        format.html
-        format.json { render json: invitation_show_json }
-      end
-    end
-
-    # POST /invitations/:token/accept
-    # Accept an invitation (public route)
-    def accept
-      # Require authentication to accept
-      unless current_user
-        # Store invitation token in session for post-signup acceptance
-        session[:pending_invitation_token] = @invitation.token
-
-        respond_to do |format|
-          format.html do
-            redirect_to main_app.respond_to?(:new_user_registration_path) ?
-              main_app.new_user_registration_path :
-              main_app.root_path,
-              alert: "Please sign in or create an account to accept this invitation."
-          end
-          format.json { render json: { error: "Authentication required" }, status: :unauthorized }
-        end
-        return
-      end
-
-      # Verify email matches (for security)
-      unless current_user.email.downcase == @invitation.email.downcase
-        respond_to do |format|
-          format.html { redirect_to invitation_path(@invitation.token), alert: "This invitation was sent to a different email address." }
-          format.json { render json: { error: "Email mismatch" }, status: :forbidden }
-        end
-        return
-      end
-
-      begin
-        membership = @invitation.accept!(current_user)
-
-        # Switch to the new organization
-        switch_to_organization!(@invitation.organization)
-
-        respond_to do |format|
-          format.html { redirect_to after_accept_path, notice: "Welcome to #{@invitation.organization.name}!" }
-          format.json { render json: { membership: membership_json(membership) }, status: :created }
-        end
-      rescue ::Organizations::InvitationExpired
-        respond_to do |format|
-          format.html { redirect_to main_app.root_path, alert: "This invitation has expired. Please request a new one." }
-          format.json { render json: { error: "Invitation expired" }, status: :gone }
-        end
-      rescue ::Organizations::InvitationAlreadyAccepted
-        respond_to do |format|
-          format.html { redirect_to after_accept_path, notice: "You're already a member of #{@invitation.organization.name}." }
-          format.json { render json: { message: "Already accepted" }, status: :ok }
-        end
-      end
-    end
-
     # DELETE /invitations/:id
     # Revoke/delete an invitation
     def destroy
@@ -162,47 +94,8 @@ module Organizations
       params.require(:invitation).permit(:email, :role)
     end
 
-    def set_invitation_by_token
-      @invitation = ::Organizations::Invitation.find_by!(token: params[:token])
-    rescue ActiveRecord::RecordNotFound
-      respond_to do |format|
-        format.html { redirect_to main_app.root_path, alert: "Invitation not found or has been revoked." }
-        format.json { render json: { error: "Invitation not found" }, status: :not_found }
-      end
-    end
-
-    def set_invitation_by_id
+    def set_invitation
       @invitation = current_organization.invitations.find(params[:id])
-    end
-
-    # Override to handle public routes where authentication is skipped
-    # Avoids infinite recursion when method_name == :current_user
-    def current_user
-      return @_current_user if defined?(@_current_user)
-
-      method_name = ::Organizations.configuration.current_user_method
-
-      # Avoid infinite recursion: if configured method is :current_user,
-      # call the parent implementation, not this method
-      @_current_user = if method_name == :current_user
-                         super rescue nil
-                       elsif respond_to?(method_name, true)
-                         send(method_name)
-                       end
-    end
-
-    def user_exists_for_invitation?
-      # Check if a user exists with this email
-      # This requires knowledge of the User model
-      if defined?(User) && User.respond_to?(:exists?)
-        User.exists?(email: @invitation.email.downcase)
-      else
-        false
-      end
-    end
-
-    def after_accept_path
-      main_app.respond_to?(:root_path) ? main_app.root_path : "/"
     end
 
     # JSON serialization helpers
@@ -226,36 +119,6 @@ module Organizations
         expires_at: invitation.expires_at,
         accepted_at: invitation.accepted_at,
         created_at: invitation.created_at
-      }
-    end
-
-    def invitation_show_json
-      inviter = @invitation.invited_by
-      inviter_name = if inviter
-                       inviter.respond_to?(:name) && inviter.name.present? ? inviter.name : inviter.email
-                     else
-                       "Someone"
-                     end
-      {
-        invitation: {
-          organization_name: @invitation.organization.name,
-          role: @invitation.role,
-          invited_by_name: inviter_name,
-          status: @invitation.status,
-          expires_at: @invitation.expires_at
-        },
-        user_exists: @user_exists,
-        user_is_logged_in: @user_is_logged_in,
-        user_email_matches: @user_email_matches
-      }
-    end
-
-    def membership_json(membership)
-      {
-        id: membership.id,
-        organization_id: membership.organization_id,
-        role: membership.role,
-        created_at: membership.created_at
       }
     end
   end

--- a/app/controllers/organizations/public_controller.rb
+++ b/app/controllers/organizations/public_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Organizations
+  # Base controller for public routes that don't require authentication.
+  # Inherits from the configured public_controller (defaults to ActionController::Base)
+  # to avoid inheriting host app filters that might enforce authentication.
+  #
+  # Use cases:
+  # - Invitation acceptance pages (users clicking email links)
+  # - Any other routes that should work for unauthenticated users
+  #
+  class PublicController < (Organizations.configuration.public_controller.constantize rescue ActionController::Base)
+    # Protect from forgery if available
+    protect_from_forgery with: :exception if respond_to?(:protect_from_forgery)
+
+    # Include main app route helpers so host app layouts work correctly
+    # (e.g., root_path, pricing_path in navbar partials)
+    include Rails.application.routes.url_helpers if defined?(Rails.application.routes.url_helpers)
+    helper Rails.application.routes.url_helpers if respond_to?(:helper)
+
+    # Minimal helpers needed for public routes
+    helper_method :current_user if respond_to?(:helper_method)
+
+    private
+
+    # Returns the current user from the host application (if any).
+    # Uses the configured method name (defaults to :current_user)
+    def current_user
+      return @_current_user if defined?(@_current_user)
+
+      user_method = Organizations.configuration.current_user_method
+
+      @_current_user = if user_method && respond_to?(user_method, true) && user_method != :current_user
+                         send(user_method)
+                       elsif defined?(super)
+                         super rescue nil
+                       end
+    end
+
+    # Access main_app routes from engine views
+    def main_app
+      Rails.application.routes.url_helpers
+    end
+    helper_method :main_app if respond_to?(:helper_method)
+  end
+end

--- a/app/controllers/organizations/public_invitations_controller.rb
+++ b/app/controllers/organizations/public_invitations_controller.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module Organizations
+  # Controller for public invitation routes (show and accept).
+  # Inherits from PublicController to avoid host app authentication filters.
+  #
+  # Routes:
+  #   GET  /invitations/:token        → View invitation details
+  #   POST /invitations/:token/accept → Accept the invitation
+  #
+  class PublicInvitationsController < PublicController
+    include Organizations::Controller if defined?(Organizations::Controller)
+
+    before_action :set_invitation
+
+    # Use the same view path as InvitationsController so host apps
+    # don't need to duplicate views for public routes
+    def self.controller_path
+      "organizations/invitations"
+    end
+
+    # GET /invitations/:token
+    # View invitation details (public route)
+    def show
+      @user_exists = user_exists_for_invitation?
+      @user_is_logged_in = current_user.present?
+      @user_email_matches = @user_is_logged_in && current_user.email.downcase == @invitation.email.downcase
+
+      respond_to do |format|
+        format.html
+        format.json { render json: invitation_show_json }
+      end
+    end
+
+    # POST /invitations/:token/accept
+    # Accept an invitation (public route)
+    def accept
+      # Require authentication to accept
+      unless current_user
+        # Store invitation token in session for post-signup acceptance
+        session[:pending_invitation_token] = @invitation.token
+
+        respond_to do |format|
+          format.html do
+            redirect_to main_app.respond_to?(:new_user_registration_path) ?
+              main_app.new_user_registration_path :
+              main_app.root_path,
+              alert: "Please sign in or create an account to accept this invitation."
+          end
+          format.json { render json: { error: "Authentication required" }, status: :unauthorized }
+        end
+        return
+      end
+
+      # Verify email matches (for security)
+      unless current_user.email.downcase == @invitation.email.downcase
+        respond_to do |format|
+          format.html { redirect_to invitation_path(@invitation.token), alert: "This invitation was sent to a different email address." }
+          format.json { render json: { error: "Email mismatch" }, status: :forbidden }
+        end
+        return
+      end
+
+      begin
+        membership = @invitation.accept!(current_user)
+
+        # Switch to the new organization if the controller supports it
+        if respond_to?(:switch_to_organization!, true)
+          switch_to_organization!(@invitation.organization)
+        elsif respond_to?(:current_organization=, true)
+          self.current_organization = @invitation.organization
+        end
+
+        respond_to do |format|
+          format.html { redirect_to after_accept_path, notice: "Welcome to #{@invitation.organization.name}!" }
+          format.json { render json: { membership: membership_json(membership) }, status: :created }
+        end
+      rescue ::Organizations::InvitationExpired
+        respond_to do |format|
+          format.html { redirect_to main_app.root_path, alert: "This invitation has expired. Please request a new one." }
+          format.json { render json: { error: "Invitation expired" }, status: :gone }
+        end
+      rescue ::Organizations::InvitationAlreadyAccepted
+        respond_to do |format|
+          format.html { redirect_to after_accept_path, notice: "You're already a member of #{@invitation.organization.name}." }
+          format.json { render json: { message: "Already accepted" }, status: :ok }
+        end
+      end
+    end
+
+    private
+
+    def set_invitation
+      @invitation = ::Organizations::Invitation.find_by!(token: params[:token])
+    rescue ActiveRecord::RecordNotFound
+      respond_to do |format|
+        format.html { redirect_to main_app.root_path, alert: "Invitation not found or has been revoked." }
+        format.json { render json: { error: "Invitation not found" }, status: :not_found }
+      end
+    end
+
+    def user_exists_for_invitation?
+      if defined?(User) && User.respond_to?(:exists?)
+        User.exists?(email: @invitation.email.downcase)
+      else
+        false
+      end
+    end
+
+    def after_accept_path
+      main_app.respond_to?(:root_path) ? main_app.root_path : "/"
+    end
+
+    # JSON serialization helpers
+
+    def invitation_show_json
+      inviter = @invitation.invited_by
+      inviter_name = if inviter
+                       inviter.respond_to?(:name) && inviter.name.present? ? inviter.name : inviter.email
+                     else
+                       "Someone"
+                     end
+      {
+        invitation: {
+          organization_name: @invitation.organization.name,
+          role: @invitation.role,
+          invited_by_name: inviter_name,
+          status: @invitation.status,
+          expires_at: @invitation.expires_at
+        },
+        user_exists: @user_exists,
+        user_is_logged_in: @user_is_logged_in,
+        user_email_matches: @user_email_matches
+      }
+    end
+
+    def membership_json(membership)
+      {
+        id: membership.id,
+        organization_id: membership.organization_id,
+        role: membership.role,
+        created_at: membership.created_at
+      }
+    end
+
+    # Route helpers for engine routes
+    def invitation_path(token)
+      Organizations::Engine.routes.url_helpers.invitation_path(token)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,9 +27,11 @@ Organizations::Engine.routes.draw do
   end
 
   # Invitation acceptance (public routes with token)
+  # These use PublicInvitationsController which inherits from a minimal base controller
+  # to avoid host app filters that might enforce authentication.
   # GET  /invitations/:token        → View invitation details
   # POST /invitations/:token/accept → Accept the invitation
   # NOTE: These must come AFTER resourceful routes to avoid matching "new" as a token
-  get "invitations/:token", to: "invitations#show", as: :invitation
-  post "invitations/:token/accept", to: "invitations#accept", as: :accept_invitation
+  get "invitations/:token", to: "public_invitations#show", as: :invitation
+  post "invitations/:token/accept", to: "public_invitations#accept", as: :accept_invitation
 end

--- a/lib/generators/organizations/install/templates/initializer.rb
+++ b/lib/generators/organizations/install/templates/initializer.rb
@@ -71,4 +71,17 @@ Organizations.configure do |config|
   # Default: :current_organization_id
   # config.session_key = :current_organization_id
 
+  # ============================================================================
+  # ENGINE CONTROLLERS
+  # ============================================================================
+
+  # Base controller for authenticated routes (default: ::ApplicationController)
+  # All organization management controllers inherit from this.
+  # config.parent_controller = "::ApplicationController"
+
+  # Base controller for public routes like invitation acceptance.
+  # Uses a minimal base to avoid host app filters that enforce authentication.
+  # Default: ActionController::Base
+  # config.public_controller = "ActionController::Base"
+
 end

--- a/lib/organizations/configuration.rb
+++ b/lib/organizations/configuration.rb
@@ -68,7 +68,12 @@ module Organizations
     attr_accessor :redirect_path_when_no_organization
 
     # === Engine configuration ===
+    # Base controller for authenticated routes (default: ::ApplicationController)
     attr_accessor :parent_controller
+
+    # Base controller for public routes like invitation acceptance (default: ActionController::Base)
+    # Use this to avoid inheriting host app filters that enforce authentication
+    attr_accessor :public_controller
 
     # === Handlers (blocks) ===
     # @private - stored handler blocks
@@ -115,6 +120,7 @@ module Organizations
 
       # Engine
       @parent_controller = "::ApplicationController"
+      @public_controller = "ActionController::Base"
 
       # Handlers (nil by default - use default behavior)
       @unauthorized_handler = nil

--- a/test/dummy/config/initializers/organizations.rb
+++ b/test/dummy/config/initializers/organizations.rb
@@ -16,6 +16,11 @@ Organizations.configure do |config|
   # How long invitations are valid
   config.invitation_expiry = 7.days
 
+  # === Engine Controllers ===
+  # Base controller for public routes (invitation acceptance, etc.)
+  # Uses minimal base to avoid host app authentication filters
+  config.public_controller = "ActionController::Base"
+
   # === Handlers ===
   # Called when authorization fails
   config.on_unauthorized do |context|


### PR DESCRIPTION
## Summary

Introduces a separate base controller for public routes (like invitation acceptance) that don't require authentication.

**The problem:** Host apps often add authentication filters to their `ApplicationController`. Since engine controllers inherit from the host's `ApplicationController`, these filters interfere with public routes like viewing/accepting invitations.

**The solution:** Add a `public_controller` config option (defaults to `ActionController::Base`) and a new `PublicController` base class. Public routes now use `PublicInvitationsController` which inherits from this minimal base, avoiding host app filter pollution.

## Changes

- Add `config.public_controller` option (default: `ActionController::Base`)
- Add `Organizations::PublicController` base class
- Add `Organizations::PublicInvitationsController` for show/accept actions
- Update routes to use new controller for invitation acceptance
- Clean up `InvitationsController` (remove public actions)
- Update README with new config option

## Usage

```ruby
# config/initializers/organizations.rb
Organizations.configure do |config|
  # Default - uses minimal base controller
  config.public_controller = "ActionController::Base"
  
  # Or use a custom slim controller from your app
  config.public_controller = "PublicBaseController"
end
```

## Test plan

- [x] All 753 existing tests pass
- [ ] Manual test: invitation acceptance works for unauthenticated users
- [ ] Manual test: host app filters don't interfere with public routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)