### PR TITLE
Avoid N+1 extra SQL in owner_membership when memberships are preloaded

### DIFF
--- a/lib/organizations/models/organization.rb
+++ b/lib/organizations/models/organization.rb
@@ -248,7 +248,9 @@ module Organizations
         # Lock organization first to prevent concurrent operations
         lock!
 
-        old_owner_membership = owner_membership
+        # Always perform a fresh read in this write path, even if memberships
+        # are preloaded on this instance, to avoid stale-owner selection.
+        old_owner_membership = memberships.find_by(role: "owner")
         new_owner_membership = memberships.find_by(user_id: new_owner.id)
 
         unless old_owner_membership

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -183,6 +183,14 @@ module Organizations
       assert_empty queries
     end
 
+    test "owner_membership returns nil when memberships are preloaded but no owner exists" do
+      org = Organization.create!(name: "No Owner Org")
+      preloaded_org = Organization.includes(:memberships).find(org.id)
+
+      assert preloaded_org.association(:memberships).loaded?
+      assert_nil preloaded_org.owner_membership
+    end
+
     test "owner avoids SQL when memberships and users are preloaded" do
       org, owner = create_org_with_owner!
       preloaded_org = Organization.includes(memberships: :user).find(org.id)
@@ -484,6 +492,26 @@ module Organizations
       assert_raises(Organization::CannotTransferToNonAdmin) do
         org.transfer_ownership_to!(viewer)
       end
+    end
+
+    test "transfer_ownership_to! uses fresh owner lookup when memberships are preloaded and stale" do
+      org, original_owner = create_org_with_owner!
+      first_admin = create_user!(email: "first-admin@example.com")
+      second_admin = create_user!(email: "second-admin@example.com")
+      org.add_member!(first_admin, role: :admin)
+      org.add_member!(second_admin, role: :admin)
+
+      stale_org = Organization.includes(:memberships).find(org.id)
+      assert stale_org.association(:memberships).loaded?
+
+      Organization.find(org.id).transfer_ownership_to!(first_admin)
+      stale_org.transfer_ownership_to!(second_admin)
+
+      org.reload
+      assert_equal second_admin, org.owner
+      assert_equal "admin", Membership.find_by!(organization: org, user: original_owner).role
+      assert_equal "admin", Membership.find_by!(organization: org, user: first_admin).role
+      assert_equal "owner", Membership.find_by!(organization: org, user: second_admin).role
     end
 
     # =========================================================================


### PR DESCRIPTION
## Summary
This PR removes an avoidable N+1 query pattern in `Organizations::Organization#owner_membership` and adds regression tests that lock in the preload-aware behavior.

Before this change, `owner_membership` always executed SQL via `memberships.find_by(role: "owner")`, even when `memberships` was already eager loaded.

After this change:
- If `memberships` is preloaded, owner membership is resolved in-memory.
- If `memberships` is not preloaded, behavior is unchanged (single SQL query via `find_by`).

---

## Problem
In index/admin contexts, host apps often load organizations with eager associations, for example:

```ruby
Organizations::Organization.includes(memberships: :user)
```

Even with that preload, calling:

```ruby
org.owner
# -> owner_membership -> memberships.find_by(role: "owner")
```

still issued SQL per organization row. That defeats preload intent and can produce N+1 behavior at scale.

This was observed downstream while auditing Madmin index pages in a host app (`licenseseat`) where `owner_email` was rendered per organization row.

---

## Root Cause
`owner_membership` was not association-load aware:

- It always used `memberships.find_by(...)`.
- `find_by` on an association relation performs a DB query.
- It does not reuse the already-loaded in-memory association target.

Location:
- `lib/organizations/models/organization.rb`

---

## Solution
`owner_membership` now branches based on association load state:

- Loaded path (no SQL):
  - `memberships.find { |membership| membership.role == "owner" }`
- Unloaded path (existing behavior):
  - `memberships.find_by(role: "owner")`

### Why this approach
- Minimal, targeted change.
- Preserves current semantics when not preloaded.
- Unlocks expected preload benefits when host apps eager load memberships.
- No API changes.

---

## Behavioral Compatibility
No breaking changes expected.

### Unloaded association (default case)
- **Before:** one query via `find_by`.
- **After:** one query via `find_by`.
- Result: unchanged behavior.

### Loaded association (preloaded case)
- **Before:** additional query still executed.
- **After:** resolved in memory, no extra SQL.
- Result: same returned membership, fewer queries.

### Missing owner edge case
- Method still returns `nil` when no owner membership exists.

---

## Tests Added
File:
- `test/models/organization_test.rb`

New tests:
1. `owner_membership avoids SQL when memberships are preloaded`
2. `owner avoids SQL when memberships and users are preloaded`

Also added a small local helper in the test file:
- `capture_non_schema_queries`

The helper subscribes to `sql.active_record` and filters out:
- `SCHEMA`
- `TRANSACTION`
- cached queries (`payload[:cached]`)

This keeps assertions focused on real DB work.

---

## Validation
Executed locally:

```bash
~/.rbenv/shims/bundle exec ruby -Itest test/models/organization_test.rb
~/.rbenv/shims/bundle exec rake test
```

Results:
- `organization_test.rb`: passing
- Full test suite: passing (`814 runs, 0 failures, 0 errors`)

---

## Performance Impact
This reduces query volume in common preload-heavy list pages.

Typical per-row pattern in host apps:
- Render organization owner name/email for each row.
- Organizations preloaded with memberships/users.

With this change, owner lookup no longer re-queries per row, improving:
- DB load
- response latency in larger lists
- consistency with caller preload intent

---

## Risk Assessment
Risk is low:
- Small, isolated method change.
- Unloaded path untouched.
- Regression tests cover both `owner_membership` and `owner` preload paths.

---

## Notes
This PR intentionally keeps the fix focused on `owner_membership` only. If useful, we can follow up with a small audit for similar preload-aware opportunities in other high-frequency association helper methods.
