### PR TITLE
Fix counter_cache conflict with attr_readonly (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.1] - 2026-03-17
+
+- Fixed `memberships_count` counter cache writes on `Organizations::Membership.create!`
+- Removed `attr_readonly :memberships_count`, which conflicted with Rails' native `counter_cache`
+
 ## [0.4.0] - 2026-03-17
 
 **Breaking:** `memberships_count` column is now required on the organizations table.
@@ -5,7 +10,6 @@
 - Added `memberships_count` to the install migration template (fresh installs get it automatically)
 - Switched to Rails' native `counter_cache` so in-memory organization instances stay accurate after member changes
 - `member_count` now reads directly from the counter cache (no fallback to COUNT query)
-- Marked `memberships_count` as readonly on organizations
 
 ## [0.3.1] - 2026-02-28
 

--- a/lib/organizations/models/organization.rb
+++ b/lib/organizations/models/organization.rb
@@ -46,7 +46,6 @@ module Organizations
     # === Validations ===
 
     validates :name, presence: true
-    attr_readonly :memberships_count
 
     # === Scopes ===
 

--- a/lib/organizations/version.rb
+++ b/lib/organizations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Organizations
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -655,8 +655,8 @@ module Organizations
       assert_equal 1, org.member_count
     end
 
-    test "memberships_count is readonly on organizations" do
-      assert_includes Organization.readonly_attributes, "memberships_count"
+    test "memberships_count is writable for native counter cache updates" do
+      refute_includes Organization.readonly_attributes, "memberships_count"
     end
 
     private


### PR DESCRIPTION
## Summary

Fixes a bug introduced in v0.4.0 where `Membership.create!` would fail to update the `memberships_count` counter cache.

**Root cause:** The `attr_readonly :memberships_count` added in v0.4.0 was meant to prevent manual tampering with the counter. However, Rails' native `counter_cache: true` works by directly writing to the parent model's counter column — `attr_readonly` blocks this internal write, breaking the feature entirely.

**Changes:**
- Removed `attr_readonly :memberships_count` from Organization model
- Updated test to verify the column is writable (required for counter_cache)
- Bumped version to 0.4.1
- Added changelog entry

## Test plan

- [ ] Verify `Membership.create!(organization: org, user: user)` increments `org.memberships_count`
- [ ] Verify `membership.destroy` decrements `org.memberships_count`
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)