### PR TITLE
Clarify billing permission semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 **🎮 [Try the live demo →](https://organizations.rameerez.com)**
 
-https://github.com/user-attachments/assets/2eddafe2-025b-4670-af9f-e0d5480508c5
-
 It's everything you need to turn a `User`-based app into a multi-tenant, `Organization`-based B2B SaaS (users belong in organizations, and organizations share resources and billing, etc.)
 
 It's super easy:
@@ -42,6 +40,8 @@ And check your roles / permissions in relation to that organization like this:
 current_user.is_organization_owner?     # => true
 current_user.is_organization_admin?     # => true (owners inherit admin permissions)
 ```
+
+https://github.com/user-attachments/assets/2eddafe2-025b-4670-af9f-e0d5480508c5
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ end
 
 > **Note:** This is an integration pattern, not built-in functionality. You implement the limit checks in your callbacks.
 
-If you're using [`pricing_plans`](https://github.com/rameerez/pricing_plans), you can limit how many members an organization can have based on their subscription using callbacks:
+If you're using [`pricing_plans`](https://github.com/rameerez/pricing_plans), you can limit how many members an organization can have based on their effective pricing plan using callbacks:
 
 ```ruby
 # config/initializers/pricing_plans.rb
@@ -188,7 +188,7 @@ Then hook into the `on_member_invited` callback to enforce limits. **This callba
 Organizations.configure do |config|
   config.on_member_invited do |ctx|
     org = ctx.organization
-    limit = org.current_plan.limit_for(:organization_members)
+    limit = org.current_pricing_plan.limit_for(:organization_members)
 
     if limit && org.member_count >= limit
       raise Organizations::InvitationError, "Member limit reached. Please upgrade your plan."
@@ -435,6 +435,8 @@ class SettingsController < ApplicationController
   end
 end
 ```
+
+`manage_billing` and `view_billing` are authorization checks only. They control who in the organization can access your billing UI, but they do not imply an active Stripe subscription or determine the effective pricing plan.
 
 ### Handling unauthorized access
 
@@ -1217,7 +1219,7 @@ end
 
 ### Integrates with pricing_plans
 
-Enforce member limits based on pricing plans using callbacks:
+Enforce member limits based on the effective pricing plan using callbacks:
 
 ```ruby
 # In your Organization model

--- a/lib/organizations/view_helpers.rb
+++ b/lib/organizations/view_helpers.rb
@@ -213,10 +213,7 @@ module Organizations
     # @param organization [Organizations::Organization] The organization
     # @return [Boolean]
     def can_manage_organization?(user, organization)
-      return false unless user && organization
-
-      role = user.role_in(organization)
-      role && Roles.has_permission?(role, :manage_settings)
+      user_has_permission_in_org?(user, organization, :manage_settings)
     end
 
     # Check if current user can invite members
@@ -225,10 +222,25 @@ module Organizations
     # @param organization [Organizations::Organization] The organization
     # @return [Boolean]
     def can_invite_members?(user, organization)
-      return false unless user && organization
+      user_has_permission_in_org?(user, organization, :invite_members)
+    end
 
-      role = user.role_in(organization)
-      role && Roles.has_permission?(role, :invite_members)
+    # Check if current user can view billing information
+    # Uses permission-based check to respect custom role configurations
+    # @param user [User] The user
+    # @param organization [Organizations::Organization] The organization
+    # @return [Boolean]
+    def can_view_billing?(user, organization)
+      user_has_permission_in_org?(user, organization, :view_billing)
+    end
+
+    # Check if current user can manage billing
+    # Uses permission-based check to respect custom role configurations
+    # @param user [User] The user
+    # @param organization [Organizations::Organization] The organization
+    # @return [Boolean]
+    def can_manage_billing?(user, organization)
+      user_has_permission_in_org?(user, organization, :manage_billing)
     end
 
     # Check if current user can remove a member

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -323,7 +323,7 @@ module Organizations
     end
 
     test "can_view_billing? returns true for admin" do
-      org, _owner = create_org_with_owner!(name: "Billing View Org")
+      org, _owner = create_org_with_owner!(name: "Billing View Admin Org")
       admin = create_user!(email: "billing-admin@example.com")
       Organizations::Membership.create!(user: admin, organization: org, role: "admin")
 
@@ -331,25 +331,57 @@ module Organizations
     end
 
     test "can_view_billing? returns false for member" do
-      org, _owner = create_org_with_owner!(name: "Billing View Org")
+      org, _owner = create_org_with_owner!(name: "Billing View Member Org")
       member = create_user!(email: "billing-member@example.com")
       Organizations::Membership.create!(user: member, organization: org, role: "member")
 
       refute can_view_billing?(member, org)
     end
 
+    test "can_view_billing? returns false for viewer" do
+      org, _owner = create_org_with_owner!(name: "Billing View Viewer Org")
+      viewer = create_user!(email: "billing-viewer@example.com")
+      Organizations::Membership.create!(user: viewer, organization: org, role: "viewer")
+
+      refute can_view_billing?(viewer, org)
+    end
+
+    test "can_view_billing? returns false for nil user" do
+      org, _owner = create_org_with_owner!(name: "Billing View Nil User Org")
+
+      refute can_view_billing?(nil, org)
+    end
+
+    test "can_view_billing? returns false for nil organization" do
+      user = create_user!(email: "billing-view-nil-org@example.com")
+
+      refute can_view_billing?(user, nil)
+    end
+
     test "can_manage_billing? returns true for owner" do
-      org, owner = create_org_with_owner!(name: "Billing Manage Org")
+      org, owner = create_org_with_owner!(name: "Billing Manage Owner Org")
 
       assert can_manage_billing?(owner, org)
     end
 
     test "can_manage_billing? returns false for admin" do
-      org, _owner = create_org_with_owner!(name: "Billing Manage Org")
+      org, _owner = create_org_with_owner!(name: "Billing Manage Admin Org")
       admin = create_user!(email: "billing-admin-manage@example.com")
       Organizations::Membership.create!(user: admin, organization: org, role: "admin")
 
       refute can_manage_billing?(admin, org)
+    end
+
+    test "can_manage_billing? returns false for nil user" do
+      org, _owner = create_org_with_owner!(name: "Billing Manage Nil User Org")
+
+      refute can_manage_billing?(nil, org)
+    end
+
+    test "can_manage_billing? returns false for nil organization" do
+      user = create_user!(email: "billing-manage-nil-org@example.com")
+
+      refute can_manage_billing?(user, nil)
     end
 
     test "can_remove_member? returns true for admin removing non-owner" do

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -322,6 +322,36 @@ module Organizations
       refute can_invite_members?(user, nil)
     end
 
+    test "can_view_billing? returns true for admin" do
+      org, _owner = create_org_with_owner!(name: "Billing View Org")
+      admin = create_user!(email: "billing-admin@example.com")
+      Organizations::Membership.create!(user: admin, organization: org, role: "admin")
+
+      assert can_view_billing?(admin, org)
+    end
+
+    test "can_view_billing? returns false for member" do
+      org, _owner = create_org_with_owner!(name: "Billing View Org")
+      member = create_user!(email: "billing-member@example.com")
+      Organizations::Membership.create!(user: member, organization: org, role: "member")
+
+      refute can_view_billing?(member, org)
+    end
+
+    test "can_manage_billing? returns true for owner" do
+      org, owner = create_org_with_owner!(name: "Billing Manage Org")
+
+      assert can_manage_billing?(owner, org)
+    end
+
+    test "can_manage_billing? returns false for admin" do
+      org, _owner = create_org_with_owner!(name: "Billing Manage Org")
+      admin = create_user!(email: "billing-admin-manage@example.com")
+      Organizations::Membership.create!(user: admin, organization: org, role: "admin")
+
+      refute can_manage_billing?(admin, org)
+    end
+
     test "can_remove_member? returns true for admin removing non-owner" do
       org, _owner = create_org_with_owner!(name: "Remove Org")
       admin = create_user!(email: "admin@example.com")
@@ -723,6 +753,8 @@ module Organizations
       Organizations::Membership.create!(user: viewer, organization: org, role: "viewer")
 
       refute can_invite_members?(viewer, org)
+      refute can_view_billing?(viewer, org)
+      refute can_manage_billing?(viewer, org)
       refute can_transfer_ownership?(viewer, org)
       refute can_delete_organization?(viewer, org)
       refute can_manage_organization?(viewer, org)
@@ -732,6 +764,8 @@ module Organizations
       org, owner = create_org_with_owner!(name: "Owner Perm Org")
 
       assert can_invite_members?(owner, org)
+      assert can_view_billing?(owner, org)
+      assert can_manage_billing?(owner, org)
       assert can_transfer_ownership?(owner, org)
       assert can_delete_organization?(owner, org)
       assert can_manage_organization?(owner, org)


### PR DESCRIPTION
## Summary
- clarify README language so billing permissions are not conflated with subscription state
- fix `pricing_plans` integration examples to use the effective pricing plan API
- add `can_view_billing?` and `can_manage_billing?` helper symmetry
- route billing-related view helpers through the shared permission predicate

## Testing
- `bundle exec rake test`
