### PR TITLE
Verified Joining (v0.5.0): join requests, email domains, join codes, allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [0.5.0] - 2026-07-16
+
+**Verified Joining** — users can now join organizations by proving they belong, closing three roadmap items (domain-based joining, request-to-join, roster/bulk import). Fully additive: existing installs change nothing until they enroll a domain, generate a code, or import a roster. Run `rails g organizations:upgrade` + `rails db:migrate` to get the new tables/columns.
+
+### Added
+
+- **Join requests** (`Organizations::JoinRequest`) — the mirror image of invitations (user→org). Memberships stay active-only; all pending state lives on the request (`pending → approved | rejected | withdrawn`, `:expired` derived like invitations). `user.request_to_join!(org)`, `org.approve_join_request!/reject_join_request!`, `request.withdraw!`. One open request per (org, user), DB-enforced.
+- **Email domains** (`Organizations::Domain`) — `org.add_domain!("corp.com")`. Exact, dot-boundary-safe matching (subdomains are separate domains; lookalike and multi-@ evasion shapes rejected).
+- **Emailed-code verification** — `request.start_email_verification!(email:)` + `request.verify_email_code!(code)`. Codes are 6 digits, stored as SHA-256 digests only (peppered by row id), single-use, TTL'd (15 min default), attempt-capped (5), resend-throttled. The proven address can differ from the account email — recorded as `verified_email` on the membership, **unique per organization** (one proven inbox = one member).
+- **Join codes** (`Organizations::JoinCode`) — globally-unique shareable PINs: `org.generate_join_code!(label:, requires_verified_domain_email:, auto_approve:, expires_at:, max_uses:)`, `JoinCode.redeem(code, user:)`, `code.revoke!` (rotation = revoke + regenerate). `requires_verified_domain_email` chains the email challenge per-code ("reinforced" level); `auto_approve: false` parks redemptions for manual approval. Race-safe use accounting.
+- **Allowlists / rosters** (`Organizations::AllowlistEntry`) — `org.import_allowlist!(emails, source:, membership_metadata:)` (idempotent). Rostered addresses still complete the email challenge (a leaked roster grants nothing without inbox access); entries are claimed on join.
+- **Account-email trust shortcut** — `org.join_with_account_email!(user)`: when the host user's account email is confirmed (e.g. Devise `:confirmable`) and its domain is enrolled, joining needs no code. Gate with `config.trust_confirmed_account_email`.
+- **Membership provenance** — memberships gain `joined_via` (`invited|code|domain_email|allowlist|manual`), `verified_email(_normalized)`, `verified_at`, plus `Membership#verified?`. Invitation acceptance now stamps provenance too (accepting the emailed token proves the inbox).
+- **`membership_metadata` copy-through** — domains, join codes, allowlist entries, and invitations carry a `membership_metadata` hash merged onto memberships they create (cohort tags like `{ member_kind: "student" }`) — the gem never interprets it. Invitations also gained a `metadata` column (parity with other tables).
+- **Callbacks** — `on_join_request_created`, `on_join_request_approved` (with `decided_by`, nil for auto-approvals), `on_join_request_rejected`.
+- **Config** — `verification_mailer`, `verification_code_ttl`, `verification_max_attempts`, `verification_resend_interval`, `verification_max_sends`, `verification_email_normalizer` (default collapses case/whitespace/+tags), `trust_confirmed_account_email`, `join_request_expiry`, `join_code_generator`.
+- **`Organizations::VerificationMailer`** (+ HTML/text templates), `Organizations::EmailNormalizer`, `organizations:upgrade` generator.
+
+### Notes
+
+- BYO-UI as always: the gem ships models/APIs/mailers, no controllers or views for joining. **Rate-limit your join/redemption endpoints in the host app.**
+- After-callbacks stay error-isolated: enforce hard member caps BEFORE calling approve/redeem in host code.
+
 ## [0.4.3] - 2026-03-19
 
 - Added `can_view_billing?` and `can_manage_billing?` view helpers for billing permission checks

--- a/README.md
+++ b/README.md
@@ -204,7 +204,80 @@ The `on_member_invited` callback is special — it runs in **strict mode**, mean
 
 This pattern gives you full control over how and when limits are enforced.
 
+## Verified joining: let users prove they belong
+
+Invitations cover org→user. Since v0.5.0 the gem also covers **user→org**: people who claim to belong to an organization and need to prove it. Four mechanisms, all converging on a regular `Membership` with provenance stamped on it:
+
+| Mechanism | Proof | Typical use |
+|---|---|---|
+| Request-to-join | a human approves | small teams, communities |
+| Email domain | 6-digit code emailed to `anything@yourdomain.com` | companies, universities |
+| Join code ("PIN") | possession of the code (± domain email) | posters, newsletters, classrooms |
+| Allowlist / roster | 6-digit code emailed to a rostered address | clubs with no own domain |
+
+**The key idea: the proven email is decoupled from the account email.** A user signed up with a personal Gmail can still prove they control `j.doe@acme.com` and join Acme as a verified member. The proven address is recorded on the membership (`verified_email`) and is **unique per organization** — one inbox, one member.
+
+```ruby
+# ── Request-to-join (manual approval) ──────────────────────────────────────
+request = user.request_to_join!(org, message: "I'm in the Madrid office")
+org.pending_join_requests                      # approval queue
+org.approve_join_request!(request, approved_by: admin)  # => Membership
+org.reject_join_request!(request, rejected_by: admin, reason: "unknown")
+
+# ── Email domain ───────────────────────────────────────────────────────────
+org.add_domain!("acme.com")
+request = user.request_to_join!(org)
+request.start_email_verification!(email: "j.doe@acme.com")  # emails a 6-digit code
+request.verify_email_code!("492817")           # => Membership (auto-approved)
+
+# Zero-friction shortcut when the ACCOUNT email is already confirmed
+# (e.g. Devise :confirmable) and its domain is enrolled:
+org.join_with_account_email!(user)             # => Membership, no code needed
+
+# ── Join code (PIN) ────────────────────────────────────────────────────────
+code = org.generate_join_code!(label: "office poster", max_uses: 500,
+                               expires_at: 3.months.from_now)
+Organizations::JoinCode.redeem("7FHK-2MPX", user: user)  # => Membership
+code.revoke!                                   # rotation = revoke + generate
+
+# Reinforced mode: PIN + corporate email required (per-code!)
+strict = org.generate_join_code!(requires_verified_domain_email: true)
+request = Organizations::JoinCode.redeem(strict.code, user: user)  # => JoinRequest
+request.start_email_verification!(email: "j.doe@acme.com")
+request.verify_email_code!("492817")           # => Membership
+
+# ── Allowlist / roster ─────────────────────────────────────────────────────
+org.import_allowlist!(["ana@gmail.com", "luis@yahoo.es"], source: "csv_2026-07")
+# Rostered users still complete the email challenge — a leaked roster grants
+# nothing without inbox access. The entry is claimed on join.
+```
+
+### Cohorts without the gem knowing (`membership_metadata`)
+
+Every join instrument (domain, code, allowlist entry, invitation) carries a `membership_metadata` hash that's merged onto memberships it creates. The gem never interprets it — it's your cohort/segmentation channel:
+
+```ruby
+org.add_domain!("acme.com",          membership_metadata: { member_kind: "employee" })
+org.add_domain!("students.acme.edu", membership_metadata: { member_kind: "student" })
+# later…
+membership.metadata["member_kind"]  # => "student"
+membership.joined_via               # => "domain_email"
+membership.verified_email           # => "x@students.acme.edu"
+membership.verified?                # => true
+```
+
+### Security posture
+
+- Codes are stored as **SHA-256 digests only** (peppered by row id), compared in constant time, single-use, expire after `verification_code_ttl` (15 min default), capped at `verification_max_attempts` (5) with resend throttles.
+- Emails are normalized before the uniqueness check (case, whitespace, and `+tag` plus-addressing collapse — override via `config.verification_email_normalizer`).
+- Domain matching is **exact** and evasion-hardened: `acme.com.evil.com`, `evilacme.com`, multi-`@` shapes never match; subdomains are separate domains on purpose (they often mean different cohorts).
+- BYO-UI as always: the gem ships models/APIs/mailers only. **You must rate-limit your join/redemption/verification endpoints** in the host app.
+- After-callbacks (`on_join_request_*`) are error-isolated — enforce hard member caps *before* calling approve/redeem.
+
+Upgrading an existing install: `rails g organizations:upgrade && rails db:migrate` (additive only).
+
 ## Why this gem exists
+
 
 Organizations / teams are tough to do alone. Wiring up accounts, roles, and invites by hand is a pain you only want to go through once. If you don't implement organizations / teams on day one, adding them later becomes a major refactor — the kind that touches every model, controller, and permission in your app. Even experienced Rails developers have built accounts / teams poorly multiple times before getting it right.
 
@@ -1756,9 +1829,10 @@ If your app currently has `User belongs_to :organization` (1:1), migrate to `Use
 
 ## Roadmap
 
-- [ ] Domain-based auto-join (users with @acme.com auto-join Acme org)
-- [ ] Bulk invitations (CSV upload)
-- [ ] Request-to-join workflow
+- [x] Domain-based joining (users prove control of an @acme.com inbox — shipped in 0.5.0 as part of verified joining)
+- [x] Request-to-join workflow (shipped in 0.5.0)
+- [x] Roster/allowlist bulk import (shipped in 0.5.0; covers the bulk-invite use case via `import_allowlist!`)
+- [ ] Bulk invitations (CSV upload of token invitations)
 - [ ] Organization-level audit logs
 - [ ] Team hierarchies within organizations
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ membership.verified?                # => true
 - Domain matching is **exact** and evasion-hardened: `acme.com.evil.com`, `evilacme.com`, multi-`@` shapes never match; subdomains are separate domains on purpose (they often mean different cohorts).
 - BYO-UI as always: the gem ships models/APIs/mailers only. **You must rate-limit your join/redemption/verification endpoints** in the host app.
 - After-callbacks (`on_join_request_*`) are error-isolated — enforce hard member caps *before* calling approve/redeem.
+- Verification-code delivery failures are swallowed (logged, never raised) AFTER the challenge row commits — deliberate, so a flaky mailer can't roll back state, but it means a misconfigured mailer silently strands users inside the resend-throttle window. **Monitor delivery failures for your verification mailer.**
 
 Upgrading an existing install: `rails g organizations:upgrade && rails db:migrate` (additive only).
 

--- a/app/mailers/organizations/verification_mailer.rb
+++ b/app/mailers/organizations/verification_mailer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Organizations
+  # Mailer for emailed verification codes (verified joining).
+  # Can be customized via Organizations.configuration.verification_mailer —
+  # custom mailers must implement `code_email(join_request, code)`.
+  #
+  # SECURITY: `code` is the plaintext one-time code. It exists only in this
+  # delivery path — the database stores a digest (see JoinRequest).
+  #
+  # @example
+  #   VerificationMailer.code_email(join_request, "492817").deliver_later
+  #
+  class VerificationMailer < ActionMailer::Base
+    default from: -> { default_from_address }
+
+    # Verification code email
+    # @param join_request [Organizations::JoinRequest]
+    # @param code [String] the plaintext 6-digit code
+    # @return [Mail::Message]
+    def code_email(join_request, code)
+      @join_request = join_request
+      @organization = join_request.organization
+      @code = code
+      @expires_in_minutes = ttl_minutes
+
+      mail(
+        to: join_request.verification_email,
+        subject: "#{@code} is your #{@organization.name} verification code"
+      )
+    end
+
+    private
+
+    def ttl_minutes
+      ttl = Organizations.configuration.verification_code_ttl
+      (ttl.to_i / 60.0).ceil
+    end
+
+    def default_from_address
+      if defined?(Rails) && Rails.application&.config&.action_mailer&.default_options
+        Rails.application.config.action_mailer.default_options[:from] || "noreply@example.com"
+      else
+        "noreply@example.com"
+      end
+    end
+  end
+end

--- a/app/mailers/organizations/verification_mailer.rb
+++ b/app/mailers/organizations/verification_mailer.rb
@@ -38,11 +38,16 @@ module Organizations
     end
 
     def default_from_address
+      # Deliberately identical to InvitationMailer#default_from_address —
+      # keep the two in sync. The long safe-nav chain is the defensive shape
+      # for engines that may boot without a full Rails app.
+      # rubocop:disable Style/SafeNavigationChainLength
       if defined?(Rails) && Rails.application&.config&.action_mailer&.default_options
         Rails.application.config.action_mailer.default_options[:from] || "noreply@example.com"
       else
         "noreply@example.com"
       end
+      # rubocop:enable Style/SafeNavigationChainLength
     end
   end
 end

--- a/app/models/organizations/allowlist_entry.rb
+++ b/app/models/organizations/allowlist_entry.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Reloadable entrypoint for Organizations::AllowlistEntry in Rails apps.
+# This file lives in app/models so Zeitwerk manages it, making the class
+# reload-safe. It delegates to the canonical implementation in lib/.
+load File.expand_path("../../../lib/organizations/models/allowlist_entry.rb", __dir__)

--- a/app/models/organizations/domain.rb
+++ b/app/models/organizations/domain.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Reloadable entrypoint for Organizations::Domain in Rails apps.
+# This file lives in app/models so Zeitwerk manages it, making the class
+# reload-safe. It delegates to the canonical implementation in lib/.
+load File.expand_path("../../../lib/organizations/models/domain.rb", __dir__)

--- a/app/models/organizations/join_code.rb
+++ b/app/models/organizations/join_code.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Reloadable entrypoint for Organizations::JoinCode in Rails apps.
+# This file lives in app/models so Zeitwerk manages it, making the class
+# reload-safe. It delegates to the canonical implementation in lib/.
+load File.expand_path("../../../lib/organizations/models/join_code.rb", __dir__)

--- a/app/models/organizations/join_request.rb
+++ b/app/models/organizations/join_request.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Reloadable entrypoint for Organizations::JoinRequest in Rails apps.
+# This file lives in app/models so Zeitwerk manages it, making the class
+# reload-safe. It delegates to the canonical implementation in lib/.
+load File.expand_path("../../../lib/organizations/models/join_request.rb", __dir__)

--- a/app/views/organizations/verification_mailer/code_email.html.erb
+++ b/app/views/organizations/verification_mailer/code_email.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #111827; margin: 0; padding: 24px;">
+    <p>Use this code to verify your email address and join <strong><%= @organization.name %></strong>:</p>
+
+    <p style="font-size: 32px; font-weight: 700; letter-spacing: 6px; background: #f3f4f6; border-radius: 8px; display: inline-block; padding: 12px 24px;">
+      <%= @code %>
+    </p>
+
+    <p>The code expires in <%= @expires_in_minutes %> minutes.</p>
+
+    <p style="color: #6b7280; font-size: 14px;">
+      If you didn't request this code, you can safely ignore this email —
+      nobody can join <%= @organization.name %> with your address without it.
+    </p>
+  </body>
+</html>

--- a/app/views/organizations/verification_mailer/code_email.text.erb
+++ b/app/views/organizations/verification_mailer/code_email.text.erb
@@ -1,0 +1,8 @@
+Use this code to verify your email address and join <%= @organization.name %>:
+
+  <%= @code %>
+
+The code expires in <%= @expires_in_minutes %> minutes.
+
+If you didn't request this code, you can safely ignore this email —
+nobody can join <%= @organization.name %> with your address without it.

--- a/lib/generators/organizations/install/templates/create_organizations_tables.rb.erb
+++ b/lib/generators/organizations/install/templates/create_organizations_tables.rb.erb
@@ -22,11 +22,24 @@ class CreateOrganizationsTables < ActiveRecord::Migration<%= migration_version %
       t.string :role, null: false, default: "member"
       t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
 
+      # Verified-joining provenance: how this member joined and which email
+      # address they proved control of (if any).
+      t.string :joined_via
+      t.string :verified_email
+      t.string :verified_email_normalized
+      t.datetime :verified_at
+
       t.timestamps
     end
 
     add_index :organizations_memberships, [:user_id, :organization_id], unique: true
     add_index :organizations_memberships, :role
+
+    # One proven email address => one membership per organization.
+    # NULLs never collide, so unverified memberships are unconstrained —
+    # a plain unique index gives identical semantics on every adapter.
+    add_index :organizations_memberships, [:organization_id, :verified_email_normalized],
+              unique: true, name: "index_org_memberships_verified_email_unique"
 
     # Enforce "at most one owner membership per organization" at DB level where possible.
     # Both PostgreSQL and SQLite support partial indexes with identical syntax.
@@ -48,6 +61,10 @@ class CreateOrganizationsTables < ActiveRecord::Migration<%= migration_version %
       t.string :role, null: false, default: "member"
       t.datetime :accepted_at
       t.datetime :expires_at
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+      # Copied onto the membership created when this invitation is accepted
+      # (cohort tags etc. — the gem never interprets the contents)
+      t.send(json_column_type, :membership_metadata, null: json_column_null, default: json_column_default)
 
       t.timestamps
     end
@@ -81,6 +98,110 @@ class CreateOrganizationsTables < ActiveRecord::Migration<%= migration_version %
     else
       # For other adapters, fall back to app-level validation.
       add_index :organizations_invitations, [:organization_id, :email], name: "index_organizations_invitations_on_org_and_email"
+    end
+
+    # === Verified joining ===
+
+    # Email domains owned by an organization (exact-match joining)
+    create_table :organizations_domains, id: primary_key_type do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.string :domain, null: false
+      t.send(json_column_type, :membership_metadata, null: json_column_null, default: json_column_default)
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_domains, [:organization_id, :domain], unique: true
+    add_index :organizations_domains, :domain
+
+    # Shareable join codes ("PINs") — globally unique, rotatable, cappable
+    create_table :organizations_join_codes, id: primary_key_type do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.string :code, null: false
+      t.string :label
+      t.boolean :requires_verified_domain_email, null: false, default: false
+      t.boolean :auto_approve, null: false, default: true
+      t.datetime :expires_at
+      t.integer :max_uses
+      t.integer :uses_count, null: false, default: 0
+      t.datetime :revoked_at
+      t.references :created_by, null: true, type: foreign_key_type, foreign_key: { to_table: :users }
+      t.send(json_column_type, :membership_metadata, null: json_column_null, default: json_column_default)
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_join_codes, :code, unique: true
+
+    # Pre-approved roster emails (allowlist joining)
+    create_table :organizations_allowlist_entries, id: primary_key_type do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.string :email, null: false
+      t.string :email_normalized, null: false
+      t.string :source
+      t.send(json_column_type, :membership_metadata, null: json_column_null, default: json_column_default)
+      t.datetime :claimed_at
+      t.references :claimed_by, null: true, type: foreign_key_type, foreign_key: { to_table: :users }
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_allowlist_entries, [:organization_id, :email_normalized], unique: true
+
+    # Join requests (request-to-join workflow + email-verification challenges)
+    create_table :organizations_join_requests, id: primary_key_type do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.references :user, null: false, type: foreign_key_type, foreign_key: true
+      t.string :status, null: false, default: "pending"
+      t.string :joined_via
+      t.references :join_code, null: true, type: foreign_key_type, foreign_key: { to_table: :organizations_join_codes }
+      t.string :message
+      t.string :verification_email
+      t.string :verification_email_normalized
+      t.string :verification_code_digest
+      t.datetime :verification_sent_at
+      t.datetime :verification_expires_at
+      t.integer :verification_attempts, null: false, default: 0
+      t.integer :verification_sends_count, null: false, default: 0
+      t.datetime :verified_at
+      t.references :decided_by, null: true, type: foreign_key_type, foreign_key: { to_table: :users }
+      t.datetime :decided_at
+      t.datetime :expires_at
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_join_requests, :status
+
+    # One OPEN request per (organization, user). Decided requests keep their
+    # history without blocking a fresh request.
+    if adapter.include?("postgresql") || adapter.include?("sqlite")
+      execute <<-SQL
+        CREATE UNIQUE INDEX index_org_join_requests_pending_unique
+        ON organizations_join_requests (organization_id, user_id)
+        WHERE status = 'pending'
+      SQL
+    elsif adapter.include?("mysql")
+      # MySQL doesn't support partial indexes: use a generated column that is
+      # only non-NULL for pending requests (NULLs never collide in unique indexes).
+      execute <<-SQL
+        ALTER TABLE organizations_join_requests
+        ADD COLUMN pending_user_key VARCHAR(255)
+        GENERATED ALWAYS AS (
+          CASE
+            WHEN status = 'pending' THEN CONCAT(organization_id, '-', user_id)
+            ELSE NULL
+          END
+        ) STORED
+      SQL
+
+      add_index :organizations_join_requests, :pending_user_key, unique: true, name: "index_org_join_requests_pending_unique"
+    else
+      add_index :organizations_join_requests, [:organization_id, :user_id], name: "index_org_join_requests_on_org_and_user"
     end
   end
 

--- a/lib/generators/organizations/install/templates/initializer.rb
+++ b/lib/generators/organizations/install/templates/initializer.rb
@@ -56,6 +56,59 @@ Organizations.configure do |config|
   # config.default_invitation_role = :member
 
   # ============================================================================
+  # VERIFIED JOINING (join requests, domains, join codes, allowlists)
+  # ============================================================================
+  #
+  # Users can join organizations by proving they belong:
+  #   - request-to-join:  user.request_to_join!(org) → org.approve_join_request!(...)
+  #   - email domain:     org.add_domain!("corp.com") + emailed 6-digit code
+  #   - join code (PIN):  org.generate_join_code!(...) + JoinCode.redeem(code, user:)
+  #   - allowlist/roster: org.import_allowlist!(emails) + emailed 6-digit code
+  #
+  # The gem ships models and APIs only (bring your own UI + rate limiting on
+  # your join endpoints). See the README's "Verified joining" section.
+
+  # Mailer that sends verification codes. Custom mailers must implement
+  # code_email(join_request, code).
+  # Default: "Organizations::VerificationMailer"
+  # config.verification_mailer = "Organizations::VerificationMailer"
+
+  # How long an emailed code stays valid (codes always expire).
+  # Default: 15.minutes
+  # config.verification_code_ttl = 15.minutes
+
+  # Wrong-attempt cap per challenge, and send throttles per join request.
+  # Defaults: 5 attempts, 60.seconds between sends, 5 sends max
+  # config.verification_max_attempts = 5
+  # config.verification_resend_interval = 60.seconds
+  # config.verification_max_sends = 5
+
+  # Email normalizer used for the "one proven email = one membership per org"
+  # invariant. Default collapses case, whitespace, and +tags (plus-addressing).
+  # config.verification_email_normalizer = ->(email) { ... }
+
+  # Allow org.join_with_account_email!(user) to trust a CONFIRMED account
+  # email (e.g. Devise :confirmable) as inbox proof — no emailed code needed
+  # when the account email's domain is enrolled.
+  # Default: true
+  # config.trust_confirmed_account_email = true
+
+  # How long join requests stay open before reading as expired (nil = never).
+  # Default: 30.days
+  # config.join_request_expiry = 30.days
+
+  # Custom join-code generator (default: 8 chars, ambiguity-free alphabet).
+  # config.join_code_generator = -> { SecureRandom.alphanumeric(10).upcase }
+
+  # Lifecycle callbacks:
+  # config.on_join_request_created  { |ctx| ... }  # ctx: organization, user, join_request
+  # config.on_join_request_approved { |ctx| ... }  # + membership, decided_by (nil = auto)
+  # config.on_join_request_rejected { |ctx| ... }  # + decided_by
+  #
+  # NOTE: like all after-callbacks these are error-isolated — enforce hard
+  # caps (member limits etc.) BEFORE calling approve/redeem, in your own code.
+
+  # ============================================================================
   # ROLES & PERMISSIONS
   # ============================================================================
 

--- a/lib/generators/organizations/upgrade/templates/add_verified_joining_to_organizations.rb.erb
+++ b/lib/generators/organizations/upgrade/templates/add_verified_joining_to_organizations.rb.erb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+# Upgrades organizations <= 0.4.x to 0.5.0 ("Verified Joining").
+# Additive only: no existing columns/rows are touched.
+class AddVerifiedJoiningToOrganizations < ActiveRecord::Migration<%= migration_version %>
+  def change
+    _primary_key_type, foreign_key_type = primary_and_foreign_key_types
+    adapter = connection.adapter_name.downcase
+
+    # === Membership provenance ===
+
+    add_column :organizations_memberships, :joined_via, :string
+    add_column :organizations_memberships, :verified_email, :string
+    add_column :organizations_memberships, :verified_email_normalized, :string
+    add_column :organizations_memberships, :verified_at, :datetime
+
+    # One proven email address => one membership per organization.
+    # NULLs never collide in unique indexes on every supported adapter, so
+    # existing (unverified) memberships are unconstrained.
+    add_index :organizations_memberships, [:organization_id, :verified_email_normalized],
+              unique: true, name: "index_org_memberships_verified_email_unique"
+
+    # === Invitation metadata parity ===
+
+    add_column :organizations_invitations, :metadata, json_column_type,
+               null: json_column_null, default: json_column_default
+    add_column :organizations_invitations, :membership_metadata, json_column_type,
+               null: json_column_null, default: json_column_default
+
+    # === Email domains (exact-match joining) ===
+
+    create_table :organizations_domains, id: primary_key_type_setting do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.string :domain, null: false
+      t.send(json_column_type, :membership_metadata, null: json_column_null, default: json_column_default)
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_domains, [:organization_id, :domain], unique: true
+    add_index :organizations_domains, :domain
+
+    # === Join codes ("PINs") ===
+
+    create_table :organizations_join_codes, id: primary_key_type_setting do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.string :code, null: false
+      t.string :label
+      t.boolean :requires_verified_domain_email, null: false, default: false
+      t.boolean :auto_approve, null: false, default: true
+      t.datetime :expires_at
+      t.integer :max_uses
+      t.integer :uses_count, null: false, default: 0
+      t.datetime :revoked_at
+      t.references :created_by, null: true, type: foreign_key_type, foreign_key: { to_table: :users }
+      t.send(json_column_type, :membership_metadata, null: json_column_null, default: json_column_default)
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_join_codes, :code, unique: true
+
+    # === Allowlist / roster entries ===
+
+    create_table :organizations_allowlist_entries, id: primary_key_type_setting do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.string :email, null: false
+      t.string :email_normalized, null: false
+      t.string :source
+      t.send(json_column_type, :membership_metadata, null: json_column_null, default: json_column_default)
+      t.datetime :claimed_at
+      t.references :claimed_by, null: true, type: foreign_key_type, foreign_key: { to_table: :users }
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_allowlist_entries, [:organization_id, :email_normalized], unique: true
+
+    # === Join requests ===
+
+    create_table :organizations_join_requests, id: primary_key_type_setting do |t|
+      t.references :organization, null: false, type: foreign_key_type, foreign_key: { to_table: :organizations_organizations }
+      t.references :user, null: false, type: foreign_key_type, foreign_key: true
+      t.string :status, null: false, default: "pending"
+      t.string :joined_via
+      t.references :join_code, null: true, type: foreign_key_type, foreign_key: { to_table: :organizations_join_codes }
+      t.string :message
+      t.string :verification_email
+      t.string :verification_email_normalized
+      t.string :verification_code_digest
+      t.datetime :verification_sent_at
+      t.datetime :verification_expires_at
+      t.integer :verification_attempts, null: false, default: 0
+      t.integer :verification_sends_count, null: false, default: 0
+      t.datetime :verified_at
+      t.references :decided_by, null: true, type: foreign_key_type, foreign_key: { to_table: :users }
+      t.datetime :decided_at
+      t.datetime :expires_at
+      t.send(json_column_type, :metadata, null: json_column_null, default: json_column_default)
+
+      t.timestamps
+    end
+
+    add_index :organizations_join_requests, :status
+
+    # One OPEN request per (organization, user); decided history never blocks
+    if adapter.include?("postgresql") || adapter.include?("sqlite")
+      reversible do |dir|
+        dir.up do
+          execute <<-SQL
+            CREATE UNIQUE INDEX index_org_join_requests_pending_unique
+            ON organizations_join_requests (organization_id, user_id)
+            WHERE status = 'pending'
+          SQL
+        end
+        dir.down do
+          execute "DROP INDEX IF EXISTS index_org_join_requests_pending_unique"
+        end
+      end
+    elsif adapter.include?("mysql")
+      reversible do |dir|
+        dir.up do
+          execute <<-SQL
+            ALTER TABLE organizations_join_requests
+            ADD COLUMN pending_user_key VARCHAR(255)
+            GENERATED ALWAYS AS (
+              CASE
+                WHEN status = 'pending' THEN CONCAT(organization_id, '-', user_id)
+                ELSE NULL
+              END
+            ) STORED
+          SQL
+        end
+        dir.down do
+          execute "ALTER TABLE organizations_join_requests DROP COLUMN pending_user_key"
+        end
+      end
+      add_index :organizations_join_requests, :pending_user_key, unique: true, name: "index_org_join_requests_pending_unique"
+    else
+      add_index :organizations_join_requests, [:organization_id, :user_id], name: "index_org_join_requests_on_org_and_user"
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+
+  def primary_key_type_setting
+    primary_and_foreign_key_types.first
+  end
+
+  def json_column_type
+    return :jsonb if connection.adapter_name.downcase.include?('postgresql')
+    :json
+  end
+
+  # MySQL 8+ doesn't allow default values on JSON columns.
+  def json_column_default
+    return nil if connection.adapter_name.downcase.include?('mysql')
+    {}
+  end
+
+  def json_column_null
+    connection.adapter_name.downcase.include?('mysql')
+  end
+end

--- a/lib/generators/organizations/upgrade/upgrade_generator.rb
+++ b/lib/generators/organizations/upgrade/upgrade_generator.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails/generators/base"
+require "rails/generators/active_record"
+
+module Organizations
+  module Generators
+    # Upgrades an existing organizations install (<= 0.4.x) to 0.5.0
+    # ("Verified Joining"): new tables for domains, join codes, allowlist
+    # entries and join requests, plus provenance columns on memberships and
+    # metadata columns on invitations.
+    #
+    # Fresh installs don't need this — `rails g organizations:install`
+    # already includes everything.
+    #
+    #   rails g organizations:upgrade
+    #   rails db:migrate
+    #
+    class UpgradeGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+      desc "Add the verified-joining tables/columns (organizations 0.5.0) to an existing install"
+
+      def self.next_migration_number(dir)
+        ActiveRecord::Generators::Base.next_migration_number(dir)
+      end
+
+      def create_migration_file
+        migration_template "add_verified_joining_to_organizations.rb.erb",
+                           File.join(db_migrate_path, "add_verified_joining_to_organizations.rb"),
+                           migration_version: migration_version
+      end
+
+      def display_post_upgrade_message
+        say "\n✅ organizations verified-joining migration created.", :green
+        say "\nNext steps:"
+        say "  1. Run 'rails db:migrate'."
+        say "  2. See the README's \"Verified joining\" section for the new API"
+        say "     (domains, join codes, allowlists, join requests)."
+      end
+
+      private
+
+      def migration_version
+        "[#{ActiveRecord::VERSION::STRING.to_f}]"
+      end
+    end
+  end
+end

--- a/lib/organizations.rb
+++ b/lib/organizations.rb
@@ -41,6 +41,27 @@ module Organizations
   class InvitationAlreadyAccepted < InvitationError; end
   class InvitationEmailMismatch < InvitationError; end
 
+  # Join request errors (verified joining)
+  class JoinRequestError < Error; end
+  class JoinRequestExpired < JoinRequestError; end
+  class JoinRequestAlreadyDecided < JoinRequestError; end
+
+  # Join code errors (verified joining)
+  # JoinCodeInvalid covers unknown, revoked, and expired codes — hosts should
+  # show the same generic message for all three (don't leak which codes exist).
+  class JoinCodeError < Error; end
+  class JoinCodeInvalid < JoinCodeError; end
+  class JoinCodeExhausted < JoinCodeInvalid; end
+
+  # Email verification errors (verified joining)
+  class VerificationError < JoinRequestError; end
+  class VerificationEmailNotEligible < VerificationError; end
+  class VerificationEmailAlreadyClaimed < VerificationError; end
+  class VerificationCodeInvalid < VerificationError; end
+  class VerificationCodeExpired < VerificationError; end
+  class VerificationAttemptsExceeded < VerificationError; end
+  class VerificationThrottled < VerificationError; end
+
   # === Autoload Components (lazy loading) ===
 
   autoload :Configuration, "organizations/configuration"
@@ -54,6 +75,7 @@ module Organizations
   autoload :CurrentUserResolution, "organizations/current_user_resolution"
   autoload :InvitationAcceptanceResult, "organizations/invitation_acceptance_result"
   autoload :InvitationAcceptanceFailure, "organizations/invitation_acceptance_failure"
+  autoload :EmailNormalizer, "organizations/email_normalizer"
 
   # Alias for README compatibility: `include Organizations::Controller`
   Controller = ControllerHelpers
@@ -87,6 +109,10 @@ module Organizations
     autoload :Organization, "organizations/models/organization"
     autoload :Membership, "organizations/models/membership"
     autoload :Invitation, "organizations/models/invitation"
+    autoload :Domain, "organizations/models/domain"
+    autoload :JoinCode, "organizations/models/join_code"
+    autoload :AllowlistEntry, "organizations/models/allowlist_entry"
+    autoload :JoinRequest, "organizations/models/join_request"
   end
 
   class << self

--- a/lib/organizations/callback_context.rb
+++ b/lib/organizations/callback_context.rb
@@ -11,6 +11,9 @@ module Organizations
   # - :member_removed => organization, membership, user, removed_by
   # - :role_changed => organization, membership, old_role, new_role, changed_by
   # - :ownership_transferred => organization, old_owner, new_owner
+  # - :join_request_created => organization, user, join_request
+  # - :join_request_approved => organization, user, join_request, membership, decided_by (nil for auto-approvals)
+  # - :join_request_rejected => organization, user, join_request, decided_by
   #
   # @example Accessing context data
   #   config.on_organization_created do |ctx|
@@ -30,6 +33,8 @@ module Organizations
     :new_role,        # Symbol - new role (for role_changed)
     :old_owner,       # User instance - previous owner (for ownership_transferred)
     :new_owner,       # User instance - new owner (for ownership_transferred)
+    :join_request,    # Organizations::JoinRequest instance (for join_request_* events)
+    :decided_by,      # User instance - who approved/rejected the join request (nil for auto)
     :permission,      # Symbol - the permission that was required (for unauthorized)
     :required_role,   # Symbol - the role that was required (for unauthorized)
     :metadata,        # Hash - additional contextual data

--- a/lib/organizations/callbacks.rb
+++ b/lib/organizations/callbacks.rb
@@ -38,6 +38,20 @@ module Organizations
       strict ? execute_strictly(callback, context) : execute_safely(event, callback, context)
     end
 
+    # Maps each event to its Configuration reader. Adding an event = one
+    # entry here + the EVENTS list + a Configuration attr/block method.
+    CALLBACK_READERS = {
+      organization_created: :on_organization_created_callback,
+      member_invited: :on_member_invited_callback,
+      member_joined: :on_member_joined_callback,
+      member_removed: :on_member_removed_callback,
+      role_changed: :on_role_changed_callback,
+      ownership_transferred: :on_ownership_transferred_callback,
+      join_request_created: :on_join_request_created_callback,
+      join_request_approved: :on_join_request_approved_callback,
+      join_request_rejected: :on_join_request_rejected_callback
+    }.freeze
+
     # Get the callback proc for an event
     # @param event [Symbol] The event type
     # @return [Proc, nil]
@@ -45,26 +59,8 @@ module Organizations
       config = Organizations.configuration
       return nil unless config
 
-      case event
-      when :organization_created
-        config.on_organization_created_callback
-      when :member_invited
-        config.on_member_invited_callback
-      when :member_joined
-        config.on_member_joined_callback
-      when :member_removed
-        config.on_member_removed_callback
-      when :role_changed
-        config.on_role_changed_callback
-      when :ownership_transferred
-        config.on_ownership_transferred_callback
-      when :join_request_created
-        config.on_join_request_created_callback
-      when :join_request_approved
-        config.on_join_request_approved_callback
-      when :join_request_rejected
-        config.on_join_request_rejected_callback
-      end
+      reader = CALLBACK_READERS[event]
+      reader ? config.public_send(reader) : nil
     end
 
     # Execute callback with error isolation

--- a/lib/organizations/callbacks.rb
+++ b/lib/organizations/callbacks.rb
@@ -17,6 +17,9 @@ module Organizations
       member_removed
       role_changed
       ownership_transferred
+      join_request_created
+      join_request_approved
+      join_request_rejected
     ].freeze
 
     module_function
@@ -55,6 +58,12 @@ module Organizations
         config.on_role_changed_callback
       when :ownership_transferred
         config.on_ownership_transferred_callback
+      when :join_request_created
+        config.on_join_request_created_callback
+      when :join_request_approved
+        config.on_join_request_approved_callback
+      when :join_request_rejected
+        config.on_join_request_rejected_callback
       end
     end
 

--- a/lib/organizations/configuration.rb
+++ b/lib/organizations/configuration.rb
@@ -81,6 +81,41 @@ module Organizations
     # Custom mailer for invitations (class name as string)
     attr_accessor :invitation_mailer
 
+    # === Verified Joining ===
+    # Custom mailer for email-verification codes (class name as string)
+    attr_accessor :verification_mailer
+
+    # How long an emailed verification code stays valid.
+    # Must be a Duration/Numeric — codes always expire (OTP hygiene).
+    attr_accessor :verification_code_ttl
+
+    # Maximum wrong-code attempts per challenge before it locks
+    attr_accessor :verification_max_attempts
+
+    # Minimum time between (re)sends of a verification code for one request
+    attr_accessor :verification_resend_interval
+
+    # Maximum number of code sends per join request
+    attr_accessor :verification_max_sends
+
+    # Custom email normalizer for the verified_email uniqueness invariant.
+    # nil = use Organizations::EmailNormalizer (downcase + strip + drop +tag).
+    # Can be a Proc/Lambda: ->(email) { ... } returning the normalized string.
+    attr_accessor :verification_email_normalizer
+
+    # Allow Organization#join_with_account_email! to trust a host user's
+    # already-confirmed account email (e.g. Devise :confirmable) as proof of
+    # inbox control, skipping the emailed code when the domain matches.
+    attr_accessor :trust_confirmed_account_email
+
+    # How long join requests stay pending before they read as expired
+    # (derived status, like invitations). nil = never expire.
+    attr_accessor :join_request_expiry
+
+    # Custom join code generator. nil = built-in 8-char ambiguity-free code.
+    # Can be a Proc/Lambda: -> { ... } returning the code string.
+    attr_accessor :join_code_generator
+
     # === Limits ===
     # Maximum organizations a user can own (nil = unlimited)
     attr_accessor :max_organizations_per_user
@@ -158,7 +193,10 @@ module Organizations
                 :on_member_joined_callback,
                 :on_member_removed_callback,
                 :on_role_changed_callback,
-                :on_ownership_transferred_callback
+                :on_ownership_transferred_callback,
+                :on_join_request_created_callback,
+                :on_join_request_approved_callback,
+                :on_join_request_rejected_callback
 
     # === Custom Roles ===
     # @private - custom roles definition
@@ -177,6 +215,17 @@ module Organizations
       @invitation_expiry = 7.days
       @default_invitation_role = :member
       @invitation_mailer = "Organizations::InvitationMailer"
+
+      # Verified joining defaults
+      @verification_mailer = "Organizations::VerificationMailer"
+      @verification_code_ttl = 15.minutes
+      @verification_max_attempts = 5
+      @verification_resend_interval = 60.seconds
+      @verification_max_sends = 5
+      @verification_email_normalizer = nil
+      @trust_confirmed_account_email = true
+      @join_request_expiry = 30.days
+      @join_code_generator = nil
 
       # Limits
       @max_organizations_per_user = nil
@@ -218,6 +267,9 @@ module Organizations
       @on_member_removed_callback = nil
       @on_role_changed_callback = nil
       @on_ownership_transferred_callback = nil
+      @on_join_request_created_callback = nil
+      @on_join_request_approved_callback = nil
+      @on_join_request_rejected_callback = nil
 
       # Custom roles
       @custom_roles_definition = nil
@@ -295,6 +347,29 @@ module Organizations
       @on_ownership_transferred_callback = block if block_given?
     end
 
+    # Called when a join request is created (request-to-join workflow)
+    # @yield [context] Block to execute
+    # @yieldparam context [CallbackContext] Context with organization, user, join_request
+    def on_join_request_created(&block)
+      @on_join_request_created_callback = block if block_given?
+    end
+
+    # Called when a join request is approved (manually or auto-approved).
+    # NOTE: like all after-callbacks, errors here are isolated — hosts must
+    # enforce hard caps (e.g. member limits) BEFORE approving, in their own code.
+    # @yield [context] Block to execute
+    # @yieldparam context [CallbackContext] Context with organization, user, join_request, membership, decided_by (nil for auto-approvals)
+    def on_join_request_approved(&block)
+      @on_join_request_approved_callback = block if block_given?
+    end
+
+    # Called when a join request is rejected
+    # @yield [context] Block to execute
+    # @yieldparam context [CallbackContext] Context with organization, user, join_request, decided_by
+    def on_join_request_rejected(&block)
+      @on_join_request_rejected_callback = block if block_given?
+    end
+
     # === Roles Configuration ===
 
     # Define custom roles with permissions
@@ -319,6 +394,16 @@ module Organizations
       end
     end
 
+    # Normalize an email through the configured (or default) normalizer
+    # @param email [String, nil]
+    # @return [String] normalized email
+    def normalize_verification_email(email)
+      normalizer = @verification_email_normalizer
+      return normalizer.call(email).to_s if normalizer.respond_to?(:call)
+
+      EmailNormalizer.normalize(email)
+    end
+
     # Resolve the default organization name for a user
     # @param user [Object] The user object
     # @return [String] The organization name
@@ -338,6 +423,7 @@ module Organizations
     def validate!
       validate_authentication_methods!
       validate_invitation_settings!
+      validate_verification_settings!
       validate_limits!
       validate_invitation_redirects!
       validate_no_organization_messages!
@@ -364,6 +450,40 @@ module Organizations
 
       unless Roles::HIERARCHY.include?(@default_invitation_role.to_sym)
         raise ConfigurationError, "default_invitation_role must be one of: #{Roles::HIERARCHY.join(', ')}"
+      end
+    end
+
+    def validate_verification_settings!
+      unless @verification_code_ttl.is_a?(ActiveSupport::Duration) || @verification_code_ttl.is_a?(Numeric)
+        raise ConfigurationError, "verification_code_ttl must be a Duration (e.g., 15.minutes) or Numeric — codes must expire"
+      end
+
+      unless @verification_resend_interval.is_a?(ActiveSupport::Duration) || @verification_resend_interval.is_a?(Numeric)
+        raise ConfigurationError, "verification_resend_interval must be a Duration (e.g., 60.seconds) or Numeric"
+      end
+
+      unless @verification_max_attempts.is_a?(Integer) && @verification_max_attempts >= 1
+        raise ConfigurationError, "verification_max_attempts must be an Integer of at least 1"
+      end
+
+      unless @verification_max_sends.is_a?(Integer) && @verification_max_sends >= 1
+        raise ConfigurationError, "verification_max_sends must be an Integer of at least 1"
+      end
+
+      unless @verification_email_normalizer.nil? || @verification_email_normalizer.respond_to?(:call)
+        raise ConfigurationError, "verification_email_normalizer must be nil or callable (Proc/Lambda)"
+      end
+
+      unless [true, false].include?(@trust_confirmed_account_email)
+        raise ConfigurationError, "trust_confirmed_account_email must be true or false"
+      end
+
+      unless @join_request_expiry.nil? || @join_request_expiry.is_a?(ActiveSupport::Duration) || @join_request_expiry.is_a?(Numeric)
+        raise ConfigurationError, "join_request_expiry must be a Duration (e.g., 30.days), Numeric, or nil (never expire)"
+      end
+
+      unless @join_code_generator.nil? || @join_code_generator.respond_to?(:call)
+        raise ConfigurationError, "join_code_generator must be nil or callable (Proc/Lambda)"
       end
     end
 

--- a/lib/organizations/configuration.rb
+++ b/lib/organizations/configuration.rb
@@ -454,37 +454,42 @@ module Organizations
     end
 
     def validate_verification_settings!
-      unless @verification_code_ttl.is_a?(ActiveSupport::Duration) || @verification_code_ttl.is_a?(Numeric)
-        raise ConfigurationError, "verification_code_ttl must be a Duration (e.g., 15.minutes) or Numeric — codes must expire"
-      end
-
-      unless @verification_resend_interval.is_a?(ActiveSupport::Duration) || @verification_resend_interval.is_a?(Numeric)
-        raise ConfigurationError, "verification_resend_interval must be a Duration (e.g., 60.seconds) or Numeric"
-      end
-
-      unless @verification_max_attempts.is_a?(Integer) && @verification_max_attempts >= 1
-        raise ConfigurationError, "verification_max_attempts must be an Integer of at least 1"
-      end
-
-      unless @verification_max_sends.is_a?(Integer) && @verification_max_sends >= 1
-        raise ConfigurationError, "verification_max_sends must be an Integer of at least 1"
-      end
-
-      unless @verification_email_normalizer.nil? || @verification_email_normalizer.respond_to?(:call)
-        raise ConfigurationError, "verification_email_normalizer must be nil or callable (Proc/Lambda)"
-      end
+      validate_duration_option!(@verification_code_ttl, "verification_code_ttl", "15.minutes")
+      validate_duration_option!(@verification_resend_interval, "verification_resend_interval", "60.seconds")
+      validate_positive_integer_option!(@verification_max_attempts, "verification_max_attempts")
+      validate_positive_integer_option!(@verification_max_sends, "verification_max_sends")
+      validate_callable_option!(@verification_email_normalizer, "verification_email_normalizer")
+      validate_callable_option!(@join_code_generator, "join_code_generator")
 
       unless [true, false].include?(@trust_confirmed_account_email)
         raise ConfigurationError, "trust_confirmed_account_email must be true or false"
       end
 
-      unless @join_request_expiry.nil? || @join_request_expiry.is_a?(ActiveSupport::Duration) || @join_request_expiry.is_a?(Numeric)
-        raise ConfigurationError, "join_request_expiry must be a Duration (e.g., 30.days), Numeric, or nil (never expire)"
-      end
+      return if @join_request_expiry.nil? || duration_like?(@join_request_expiry)
 
-      unless @join_code_generator.nil? || @join_code_generator.respond_to?(:call)
-        raise ConfigurationError, "join_code_generator must be nil or callable (Proc/Lambda)"
-      end
+      raise ConfigurationError, "join_request_expiry must be a Duration (e.g., 30.days), Numeric, or nil (never expire)"
+    end
+
+    def duration_like?(value)
+      value.is_a?(ActiveSupport::Duration) || value.is_a?(Numeric)
+    end
+
+    def validate_duration_option!(value, option_name, example)
+      return if duration_like?(value)
+
+      raise ConfigurationError, "#{option_name} must be a Duration (e.g., #{example}) or Numeric"
+    end
+
+    def validate_positive_integer_option!(value, option_name)
+      return if value.is_a?(Integer) && value >= 1
+
+      raise ConfigurationError, "#{option_name} must be an Integer of at least 1"
+    end
+
+    def validate_callable_option!(value, option_name)
+      return if value.nil? || value.respond_to?(:call)
+
+      raise ConfigurationError, "#{option_name} must be nil or callable (Proc/Lambda)"
     end
 
     def validate_limits!

--- a/lib/organizations/email_normalizer.rb
+++ b/lib/organizations/email_normalizer.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Organizations
+  # Default email normalization for verified joining.
+  #
+  # Verified joining enforces "one proven email address => one membership per
+  # organization" (partial unique index on memberships.verified_email_normalized).
+  # That invariant is only meaningful if trivially-aliased addresses collapse to
+  # the same normalized value, otherwise one inbox can mint unlimited "distinct"
+  # identities via plus-addressing (user+1@corp.com, user+2@corp.com, ...).
+  #
+  # Normalization rules (deliberately conservative):
+  # - downcase + strip surrounding whitespace
+  # - strip a single trailing dot from the domain (FQDN form: "corp.com.")
+  # - drop the +tag suffix from the local part (RFC 5233 subaddressing)
+  #
+  # Gmail-style dot-collapsing in the local part is intentionally NOT applied:
+  # dots are significant in most corporate mail systems, and collapsing them
+  # would wrongly merge distinct mailboxes (j.doe@ vs jdoe@).
+  #
+  # Hosts can replace this wholesale via:
+  #   config.verification_email_normalizer = ->(email) { ... }
+  #
+  # @example
+  #   EmailNormalizer.normalize("  J.Doe+carpool@INIZIO.COM. ") # => "j.doe@inizio.com"
+  #   EmailNormalizer.domain_of("j.doe@inizio.com")             # => "inizio.com"
+  #   EmailNormalizer.domain_of("evil@a.com@b.com")             # => nil (multi-@ rejected)
+  #
+  module EmailNormalizer
+    module_function
+
+    # Normalize an email address for uniqueness comparison.
+    # @param email [String, nil]
+    # @return [String] normalized email ("" for blank input)
+    def normalize(email)
+      value = email.to_s.strip.downcase
+      return "" if value.empty?
+
+      local, at, domain = value.rpartition("@")
+      return value if at.empty? # not an email shape; leave as-is (validation rejects it upstream)
+
+      local = local.split("+", 2).first.to_s
+      domain = domain.chomp(".")
+
+      "#{local}@#{domain}"
+    end
+
+    # Extract the domain of an email address, hardened against evasion shapes.
+    # Returns nil (instead of guessing) when the address doesn't have exactly
+    # one "@" — multi-@ addresses are a classic trick against naive splitting.
+    # A single trailing dot (FQDN form) is tolerated and stripped.
+    # @param email [String, nil]
+    # @return [String, nil] lowercased domain, or nil if not extractable
+    def domain_of(email)
+      value = email.to_s.strip.downcase
+      return nil if value.empty?
+      return nil unless value.count("@") == 1
+
+      domain = value.split("@", 2).last.to_s.chomp(".")
+      return nil if domain.empty? || domain.include?("@")
+
+      domain
+    end
+  end
+end

--- a/lib/organizations/models/allowlist_entry.rb
+++ b/lib/organizations/models/allowlist_entry.rb
@@ -45,7 +45,7 @@ module Organizations
     scope :unclaimed, -> { where(claimed_at: nil) }
 
     # Entries matching an email (through the configured normalizer)
-    scope :for_email, ->(email) {
+    scope :for_email, lambda { |email|
       where(email_normalized: Organizations.configuration.normalize_verification_email(email))
     }
 

--- a/lib/organizations/models/allowlist_entry.rb
+++ b/lib/organizations/models/allowlist_entry.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Organizations
+  # A pre-approved email address on an organization's roster/allowlist,
+  # used for verified joining when the organization has no email domain
+  # of its own (clubs, associations, mixed-provider orgs).
+  #
+  # A user who proves control of a rostered inbox (emailed code) becomes a
+  # verified member and the entry is marked claimed. Proof-of-control is
+  # still required — a leaked roster must never grant membership without
+  # inbox access.
+  #
+  # Entries are typically bulk-imported: see Organization#import_allowlist!.
+  #
+  # @example
+  #   org.import_allowlist!(["ana@gmail.com", "luis@yahoo.es"], source: "csv_2026-07")
+  #
+  class AllowlistEntry < ActiveRecord::Base
+    self.table_name = "organizations_allowlist_entries"
+
+    # === Associations ===
+
+    belongs_to :organization,
+               class_name: "Organizations::Organization",
+               inverse_of: :allowlist_entries
+
+    belongs_to :claimed_by,
+               class_name: "User",
+               optional: true
+
+    # === Validations ===
+
+    validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+    validates :email_normalized, presence: true,
+                                 uniqueness: { scope: :organization_id,
+                                               message: "is already on this organization's allowlist" }
+
+    # === Callbacks ===
+
+    before_validation :normalize_email
+
+    # === Scopes ===
+
+    # Entries not yet consumed by a membership
+    scope :unclaimed, -> { where(claimed_at: nil) }
+
+    # Entries matching an email (through the configured normalizer)
+    scope :for_email, ->(email) {
+      where(email_normalized: Organizations.configuration.normalize_verification_email(email))
+    }
+
+    # === Status ===
+
+    # @return [Boolean]
+    def claimed?
+      claimed_at.present?
+    end
+
+    # Mark this entry as consumed by a user's membership.
+    # Idempotent: claiming an already-claimed entry is a no-op.
+    # @param user [User]
+    # @return [self]
+    def claim!(user)
+      return self if claimed?
+
+      with_lock do
+        break if claimed?
+
+        update!(claimed_at: Time.current, claimed_by_id: user.id)
+      end
+
+      self
+    end
+
+    private
+
+    def normalize_email
+      return if email.blank?
+
+      self.email = email.to_s.strip
+      self.email_normalized = Organizations.configuration.normalize_verification_email(email)
+    end
+  end
+end

--- a/lib/organizations/models/concerns/has_organizations.rb
+++ b/lib/organizations/models/concerns/has_organizations.rb
@@ -86,6 +86,35 @@ module Organizations
                      foreign_key: :invited_by_id,
                      inverse_of: :invited_by,
                      dependent: :nullify
+
+            # === Verified joining (v0.5.0) ===
+
+            # This user's join requests (request-to-join workflow)
+            has_many :organization_join_requests,
+                     class_name: "Organizations::JoinRequest",
+                     foreign_key: :user_id,
+                     inverse_of: :user,
+                     dependent: :destroy
+
+            # Trails this user leaves as an actor on other people's records —
+            # nullified on deletion, same as sent_organization_invitations
+            has_many :decided_organization_join_requests,
+                     class_name: "Organizations::JoinRequest",
+                     foreign_key: :decided_by_id,
+                     inverse_of: :decided_by,
+                     dependent: :nullify
+
+            has_many :created_organization_join_codes,
+                     class_name: "Organizations::JoinCode",
+                     foreign_key: :created_by_id,
+                     inverse_of: :created_by,
+                     dependent: :nullify
+
+            has_many :claimed_organization_allowlist_entries,
+                     class_name: "Organizations::AllowlistEntry",
+                     foreign_key: :claimed_by_id,
+                     inverse_of: :claimed_by,
+                     dependent: :nullify
           end
 
           def define_organization_settings(options, &block)
@@ -506,6 +535,54 @@ module Organizations
             end
 
             org.send_invite_to!(email, invited_by: self, role: role)
+          end
+
+          # === Verified Joining (v0.5.0) ===
+
+          # Petition to join an organization (request-to-join workflow).
+          # Idempotent: returns the existing open request when one exists.
+          # Fires the :join_request_created callback for new requests.
+          #
+          # @param organization [Organizations::Organization]
+          # @param message [String, nil] optional note shown to approvers
+          # @return [Organizations::JoinRequest]
+          #
+          # NOTE: `max_organizations` deliberately does NOT apply here — that
+          # setting caps orgs a user can OWN. Hosts wanting to cap plain
+          # memberships should check before approving (see README).
+          def request_to_join!(organization, message: nil)
+            existing = pending_join_request_for(organization)
+            return existing if existing
+
+            # A member doesn't need to request — surface their (approved)
+            # state instead of creating a nonsense pending row.
+            existing_membership = memberships.find_by(organization_id: organization.id)
+            if existing_membership
+              raise Organizations::JoinRequestAlreadyDecided,
+                    "You are already a member of this organization"
+            end
+
+            request = organization.join_requests.create!(user: self, message: message)
+
+            Callbacks.dispatch(
+              :join_request_created,
+              organization: organization,
+              user: self,
+              join_request: request
+            )
+
+            request
+          rescue ActiveRecord::RecordNotUnique
+            # Race: a concurrent request slipped past the pre-check.
+            pending_join_request_for(organization) ||
+              raise(Organizations::JoinRequestError, "Could not create join request")
+          end
+
+          # This user's open request for an organization, if any
+          # @param organization [Organizations::Organization]
+          # @return [Organizations::JoinRequest, nil]
+          def pending_join_request_for(organization)
+            organization_join_requests.pending.find_by(organization_id: organization.id)
           end
 
           # Extension seam for personal organization creation.

--- a/lib/organizations/models/concerns/has_organizations.rb
+++ b/lib/organizations/models/concerns/has_organizations.rb
@@ -87,8 +87,11 @@ module Organizations
                      inverse_of: :invited_by,
                      dependent: :nullify
 
-            # === Verified joining (v0.5.0) ===
+            define_verified_joining_associations
+          end
 
+          # Verified-joining (v0.5.0) associations, split out for readability
+          def define_verified_joining_associations
             # This user's join requests (request-to-join workflow)
             has_many :organization_join_requests,
                      class_name: "Organizations::JoinRequest",

--- a/lib/organizations/models/domain.rb
+++ b/lib/organizations/models/domain.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Organizations
+  # An email domain owned/claimed by an organization, used for verified joining.
+  #
+  # A user who proves control of an inbox under one of the organization's
+  # domains (emailed code, or an already-confirmed account email — see
+  # Organization#join_with_account_email!) is considered a verified member.
+  #
+  # Matching is EXACT and dot-boundary safe: "alumnos.urjc.es" and "urjc.es"
+  # are two different domains and must both be enrolled if both should join.
+  # This is deliberate — subdomains often carry different member semantics
+  # (e.g. students vs employees), and suffix matching would collapse them.
+  # It also neutralizes lookalike attacks ("urjc.es.evil.com" never equals
+  # "urjc.es").
+  #
+  # `membership_metadata` is copied onto memberships created through this
+  # domain (see JoinRequest#approve!) — hosts use it for cohort tags like
+  # { "member_kind" => "student" } without the gem interpreting the contents.
+  #
+  # @example
+  #   org.add_domain!("inizio.com")
+  #   org.add_domain!("alumnos.urjc.es", membership_metadata: { member_kind: "student" })
+  #   Organizations::Domain.matching_email("j.doe@inizio.com") # => [domain]
+  #
+  class Domain < ActiveRecord::Base
+    self.table_name = "organizations_domains"
+
+    # === Associations ===
+
+    belongs_to :organization,
+               class_name: "Organizations::Organization",
+               inverse_of: :domains
+
+    # === Validations ===
+
+    validates :domain, presence: true, uniqueness: { scope: :organization_id }
+    validate :domain_shape
+
+    # === Callbacks ===
+
+    before_validation :normalize_domain
+
+    # === Scopes ===
+
+    # All domain rows (across organizations) matching an email's domain.
+    # Returns none for emails whose domain can't be safely extracted
+    # (multi-@ evasion shapes, blanks).
+    scope :matching_email, ->(email) {
+      extracted = EmailNormalizer.domain_of(email)
+      extracted ? where(domain: extracted) : none
+    }
+
+    # === Matching ===
+
+    # Whether an email address belongs to this domain (exact match).
+    # @param email [String]
+    # @return [Boolean]
+    def matches_email?(email)
+      extracted = EmailNormalizer.domain_of(email)
+      extracted.present? && extracted == domain
+    end
+
+    private
+
+    def normalize_domain
+      return if domain.blank?
+
+      self.domain = domain.to_s.strip.downcase.delete_prefix("@").chomp(".")
+    end
+
+    # Pragmatic hostname shape check: lowercase labels, at least one dot,
+    # no whitespace or "@". (IDN domains should be enrolled in punycode form.)
+    def domain_shape
+      return if domain.blank? # presence validation covers this
+
+      unless domain.match?(/\A[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+\z/)
+        errors.add(:domain, "is not a valid domain name")
+      end
+    end
+  end
+end

--- a/lib/organizations/models/domain.rb
+++ b/lib/organizations/models/domain.rb
@@ -46,7 +46,7 @@ module Organizations
     # All domain rows (across organizations) matching an email's domain.
     # Returns none for emails whose domain can't be safely extracted
     # (multi-@ evasion shapes, blanks).
-    scope :matching_email, ->(email) {
+    scope :matching_email, lambda { |email|
       extracted = EmailNormalizer.domain_of(email)
       extracted ? where(domain: extracted) : none
     }
@@ -74,7 +74,7 @@ module Organizations
     def domain_shape
       return if domain.blank? # presence validation covers this
 
-      unless domain.match?(/\A[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+\z/)
+      unless domain.match?(/\A[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+\z/)
         errors.add(:domain, "is not a valid domain name")
       end
     end

--- a/lib/organizations/models/invitation.rb
+++ b/lib/organizations/models/invitation.rb
@@ -170,10 +170,21 @@ module Organizations
         # Create the membership
         # Use invited_by_id instead of invited_by to avoid Rails class reloading issues
         # (AssociationTypeMismatch when User class is reloaded in development)
+        #
+        # Verified-joining provenance (v0.5.0): accepting the emailed token is
+        # proof of control of the invited address, so the membership records
+        # it as a verified email — UNLESS the acceptance bypassed the email
+        # match (skip_email_validation with a different account email), where
+        # no inbox proof exists. If the address was already claimed by another
+        # membership in this org (rare recycled-address edge), the membership
+        # is still created, just without the verified-email stamp.
         membership = organization.memberships.create!(
           user: accepting_user,
           role: role,
-          invited_by_id: invited_by_id
+          invited_by_id: invited_by_id,
+          joined_via: "invited",
+          metadata: membership_metadata.is_a?(Hash) ? membership_metadata : {},
+          **verified_email_attributes_for(accepting_user, skip_email_validation)
         )
 
         # Mark invitation as accepted
@@ -227,6 +238,30 @@ module Organizations
     end
 
     private
+
+    # Provenance attributes for the membership created by this acceptance.
+    # See the comment at the create! call site for the trust rules.
+    def verified_email_attributes_for(accepting_user, skip_email_validation)
+      email_proven =
+        !skip_email_validation ||
+        (accepting_user.respond_to?(:email) && for_email?(accepting_user.email))
+
+      return {} unless email_proven
+
+      normalized = Organizations.configuration.normalize_verification_email(email)
+
+      already_claimed = Membership
+                        .where(organization_id: organization_id, verified_email_normalized: normalized)
+                        .exists?
+
+      return {} if already_claimed
+
+      {
+        verified_email: email,
+        verified_email_normalized: normalized,
+        verified_at: Time.current
+      }
+    end
 
     def normalize_email
       self.email = email.to_s.downcase.strip if email.present?

--- a/lib/organizations/models/invitation.rb
+++ b/lib/organizations/models/invitation.rb
@@ -235,13 +235,32 @@ module Organizations
     # created, just without the verified-email stamp.
     def create_membership_for!(accepting_user, skip_email_validation)
       organization.memberships.create!(
+        **base_membership_attributes(accepting_user),
+        **verified_email_attributes_for(accepting_user, skip_email_validation)
+      )
+    rescue ActiveRecord::RecordNotUnique
+      # Two unique indexes can fire here (same disambiguation as
+      # JoinRequest#create_membership!):
+      # 1. (user, org) — another acceptance/join path just made them a member:
+      #    reuse it (invitations to one address aren't normalization-aware, so
+      #    two plus-variant invitations can race).
+      # 2. (org, verified_email_normalized) — the address was claimed between
+      #    our pre-check and the INSERT: degrade gracefully by creating the
+      #    membership WITHOUT the verified-email stamp. Acceptance never breaks.
+      existing = organization.memberships.find_by(user_id: accepting_user.id)
+      return existing if existing
+
+      organization.memberships.create!(**base_membership_attributes(accepting_user))
+    end
+
+    def base_membership_attributes(accepting_user)
+      {
         user: accepting_user,
         role: role,
         invited_by_id: invited_by_id,
         joined_via: "invited",
-        metadata: membership_metadata.is_a?(Hash) ? membership_metadata : {},
-        **verified_email_attributes_for(accepting_user, skip_email_validation)
-      )
+        metadata: membership_metadata.is_a?(Hash) ? membership_metadata : {}
+      }
     end
 
     # Provenance attributes for the membership created by this acceptance.

--- a/lib/organizations/models/invitation.rb
+++ b/lib/organizations/models/invitation.rb
@@ -167,25 +167,8 @@ module Organizations
           return existing_membership
         end
 
-        # Create the membership
-        # Use invited_by_id instead of invited_by to avoid Rails class reloading issues
-        # (AssociationTypeMismatch when User class is reloaded in development)
-        #
-        # Verified-joining provenance (v0.5.0): accepting the emailed token is
-        # proof of control of the invited address, so the membership records
-        # it as a verified email — UNLESS the acceptance bypassed the email
-        # match (skip_email_validation with a different account email), where
-        # no inbox proof exists. If the address was already claimed by another
-        # membership in this org (rare recycled-address edge), the membership
-        # is still created, just without the verified-email stamp.
-        membership = organization.memberships.create!(
-          user: accepting_user,
-          role: role,
-          invited_by_id: invited_by_id,
-          joined_via: "invited",
-          metadata: membership_metadata.is_a?(Hash) ? membership_metadata : {},
-          **verified_email_attributes_for(accepting_user, skip_email_validation)
-        )
+        # Create the membership (with verified-joining provenance)
+        membership = create_membership_for!(accepting_user, skip_email_validation)
 
         # Mark invitation as accepted
         update!(accepted_at: Time.current)
@@ -239,8 +222,30 @@ module Organizations
 
     private
 
+    # Create the membership for an acceptance.
+    # Uses invited_by_id instead of invited_by to avoid Rails class reloading
+    # issues (AssociationTypeMismatch when User is reloaded in development).
+    #
+    # Verified-joining provenance (v0.5.0): accepting the emailed token is
+    # proof of control of the invited address, so the membership records it
+    # as a verified email — UNLESS the acceptance bypassed the email match
+    # (skip_email_validation with a different account email), where no inbox
+    # proof exists. If the address was already claimed by another membership
+    # in this org (rare recycled-address edge), the membership is still
+    # created, just without the verified-email stamp.
+    def create_membership_for!(accepting_user, skip_email_validation)
+      organization.memberships.create!(
+        user: accepting_user,
+        role: role,
+        invited_by_id: invited_by_id,
+        joined_via: "invited",
+        metadata: membership_metadata.is_a?(Hash) ? membership_metadata : {},
+        **verified_email_attributes_for(accepting_user, skip_email_validation)
+      )
+    end
+
     # Provenance attributes for the membership created by this acceptance.
-    # See the comment at the create! call site for the trust rules.
+    # See create_membership_for! for the trust rules.
     def verified_email_attributes_for(accepting_user, skip_email_validation)
       email_proven =
         !skip_email_validation ||

--- a/lib/organizations/models/join_code.rb
+++ b/lib/organizations/models/join_code.rb
@@ -142,9 +142,7 @@ module Organizations
         # be race-safe (two concurrent redemptions of a max_uses: 1 code must
         # yield exactly one success).
         lock!
-
-        raise JoinCodeInvalid, "This code is not valid" if revoked? || expired?
-        raise JoinCodeExhausted, "This code has reached its usage limit" if exhausted?
+        ensure_redeemable!
 
         # Already a member — idempotent no-op that does NOT consume a use.
         existing_membership = organization.memberships.find_by(user_id: user.id)
@@ -153,18 +151,7 @@ module Organizations
           raise ActiveRecord::Rollback # nothing to persist
         end
 
-        request = pending_request_for(user)
-
-        if request.persisted? && request.join_code_id == id
-          # Same user re-redeeming the same code: idempotent, no extra use.
-          outcome = request
-        else
-          request.join_code = self
-          request.joined_via = "code"
-          request.save!
-          increment!(:uses_count)
-          outcome = request
-        end
+        outcome = attach_request!(user)
       end
 
       # Instant-join path: no email challenge required and auto-approve on.
@@ -172,21 +159,40 @@ module Organizations
       # member_joined/join_request_approved callbacks never fire for a
       # transaction that could still roll back. If approval fails, the
       # pending request survives — a safe, resumable state.
-      if outcome.is_a?(JoinRequest) && !requires_verified_domain_email? && auto_approve?
-        outcome = outcome.approve!(decided_by: nil)
-      end
+      return outcome unless outcome.is_a?(JoinRequest)
+      return outcome if requires_verified_domain_email? || !auto_approve?
 
-      outcome
+      outcome.approve!(decided_by: nil)
     end
 
     # Normalize user input to storage form: uppercase, strip separators.
     # @param code [String, nil]
     # @return [String]
     def self.normalize(code)
-      code.to_s.upcase.gsub(/[\s\-]/, "")
+      code.to_s.upcase.gsub(/[\s-]/, "")
     end
 
     private
+
+    def ensure_redeemable!
+      raise JoinCodeInvalid, "This code is not valid" if revoked? || expired?
+      raise JoinCodeExhausted, "This code has reached its usage limit" if exhausted?
+    end
+
+    # Attach this code to the user's open request (creating one if needed),
+    # consuming a use — except for idempotent re-redemptions of the same code.
+    def attach_request!(user)
+      request = pending_request_for(user)
+
+      # Same user re-redeeming the same code: idempotent, no extra use.
+      return request if request.persisted? && request.join_code_id == id
+
+      request.join_code = self
+      request.joined_via = "code"
+      request.save!
+      increment!(:uses_count)
+      request
+    end
 
     # Find or build this user's open request for the organization.
     # Reuses an existing pending request (partial unique index: one pending

--- a/lib/organizations/models/join_code.rb
+++ b/lib/organizations/models/join_code.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+module Organizations
+  # A shareable join code ("PIN") for an organization — the classroom/Slack
+  # style joining mechanism. Codes are globally unique so redemption needs no
+  # organization context (QR posters, links, plain typing).
+  #
+  # Per-code knobs:
+  # - `requires_verified_domain_email` — redemption additionally requires the
+  #   emailed-code challenge against one of the org's domains (the "reinforced"
+  #   level). Per-code (not per-org) so one org can run both levels at once.
+  # - `auto_approve` — false means redemption parks a pending JoinRequest for
+  #   manual approval instead of granting membership immediately.
+  # - `expires_at`, `max_uses`, `revoked_at` — abuse containment. Rotation is
+  #   revoke + generate a new code (history preserved for audit).
+  # - `label` — campaign attribution ("cafeteria poster" vs "newsletter").
+  #
+  # `membership_metadata` is copied onto memberships created through this code.
+  #
+  # @example
+  #   code = org.generate_join_code!(label: "poster", requires_verified_domain_email: true)
+  #   Organizations::JoinCode.redeem(code.code, user: user)
+  #   # => Membership (instant join) or JoinRequest (challenge/approval pending)
+  #
+  class JoinCode < ActiveRecord::Base
+    self.table_name = "organizations_join_codes"
+
+    # Ambiguity-free alphabet (no I/L/O/0/1 lookalikes) — same idea as
+    # user-facing referral codes: survives posters, print, and dictation.
+    CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+    DEFAULT_CODE_LENGTH = 8
+
+    # === Associations ===
+
+    belongs_to :organization,
+               class_name: "Organizations::Organization",
+               inverse_of: :join_codes
+
+    belongs_to :created_by,
+               class_name: "User",
+               optional: true
+
+    has_many :join_requests,
+             class_name: "Organizations::JoinRequest",
+             inverse_of: :join_code
+
+    # === Validations ===
+
+    validates :code, presence: true, uniqueness: true
+    validates :max_uses, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
+    validates :uses_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+    # === Callbacks ===
+
+    before_validation :normalize_code
+    before_validation :generate_code, on: :create, if: -> { code.blank? }
+
+    # === Scopes ===
+
+    scope :not_revoked, -> { where(revoked_at: nil) }
+
+    # === Status ===
+
+    # @return [Boolean]
+    def revoked?
+      revoked_at.present?
+    end
+
+    # @return [Boolean]
+    def expired?
+      expires_at.present? && expires_at <= Time.current
+    end
+
+    # @return [Boolean]
+    def exhausted?
+      max_uses.present? && uses_count >= max_uses
+    end
+
+    # @return [Boolean]
+    def active?
+      !revoked? && !expired? && !exhausted?
+    end
+
+    # @return [Symbol] :active, :revoked, :expired, or :exhausted
+    def status
+      return :revoked if revoked?
+      return :expired if expired?
+      return :exhausted if exhausted?
+
+      :active
+    end
+
+    # Revoke this code (rotation = revoke + generate a new one). Idempotent.
+    # @return [self]
+    def revoke!
+      return self if revoked?
+
+      with_lock do
+        break if revoked?
+
+        update!(revoked_at: Time.current)
+      end
+
+      self
+    end
+
+    # Presentation form, grouped for readability: "7FHK2MPX" => "7FHK-2MPX".
+    # Storage and matching always use the bare form.
+    # @return [String]
+    def display_code
+      code.to_s.scan(/.{1,4}/).join("-")
+    end
+
+    # === Redemption ===
+
+    # Redeem a code for a user.
+    # @param code [String] the code as typed (case/hyphen/space insensitive)
+    # @param user [User] the redeeming user
+    # @return [Membership] when the code grants instant membership (or the
+    #   user is already a member)
+    # @return [JoinRequest] when a challenge or manual approval is still needed
+    # @raise [JoinCodeInvalid] for unknown, revoked, or expired codes
+    # @raise [JoinCodeExhausted] when max_uses is spent
+    def self.redeem(code, user:)
+      normalized = normalize(code)
+      raise JoinCodeInvalid, "This code is not valid" if normalized.blank?
+
+      join_code = find_by(code: normalized)
+      raise JoinCodeInvalid, "This code is not valid" unless join_code
+
+      join_code.redeem!(user: user)
+    end
+
+    # Instance-level redemption. See .redeem for semantics.
+    def redeem!(user:)
+      raise ArgumentError, "user is required" unless user
+
+      outcome = nil
+
+      ActiveRecord::Base.transaction do
+        # Lock the code row: uses_count accounting and the max_uses cap must
+        # be race-safe (two concurrent redemptions of a max_uses: 1 code must
+        # yield exactly one success).
+        lock!
+
+        raise JoinCodeInvalid, "This code is not valid" if revoked? || expired?
+        raise JoinCodeExhausted, "This code has reached its usage limit" if exhausted?
+
+        # Already a member — idempotent no-op that does NOT consume a use.
+        existing_membership = organization.memberships.find_by(user_id: user.id)
+        if existing_membership
+          outcome = existing_membership
+          raise ActiveRecord::Rollback # nothing to persist
+        end
+
+        request = pending_request_for(user)
+
+        if request.persisted? && request.join_code_id == id
+          # Same user re-redeeming the same code: idempotent, no extra use.
+          outcome = request
+        else
+          request.join_code = self
+          request.joined_via = "code"
+          request.save!
+          increment!(:uses_count)
+          outcome = request
+        end
+      end
+
+      # Instant-join path: no email challenge required and auto-approve on.
+      # Approval runs AFTER the redemption transaction commits so the
+      # member_joined/join_request_approved callbacks never fire for a
+      # transaction that could still roll back. If approval fails, the
+      # pending request survives — a safe, resumable state.
+      if outcome.is_a?(JoinRequest) && !requires_verified_domain_email? && auto_approve?
+        outcome = outcome.approve!(decided_by: nil)
+      end
+
+      outcome
+    end
+
+    # Normalize user input to storage form: uppercase, strip separators.
+    # @param code [String, nil]
+    # @return [String]
+    def self.normalize(code)
+      code.to_s.upcase.gsub(/[\s\-]/, "")
+    end
+
+    private
+
+    # Find or build this user's open request for the organization.
+    # Reuses an existing pending request (partial unique index: one pending
+    # request per user per org) so re-entry via a different mechanism upgrades
+    # the same request instead of exploding.
+    def pending_request_for(user)
+      organization.join_requests.pending.find_by(user_id: user.id) ||
+        organization.join_requests.new(user: user)
+    end
+
+    def normalize_code
+      self.code = self.class.normalize(code) if code.present?
+    end
+
+    def generate_code
+      generator = Organizations.configuration.join_code_generator
+
+      self.code = loop do
+        candidate =
+          if generator.respond_to?(:call)
+            self.class.normalize(generator.call)
+          else
+            Array.new(DEFAULT_CODE_LENGTH) { CODE_ALPHABET[SecureRandom.random_number(CODE_ALPHABET.length)] }.join
+          end
+
+        break candidate unless self.class.exists?(code: candidate)
+      end
+    end
+  end
+end

--- a/lib/organizations/models/join_request.rb
+++ b/lib/organizations/models/join_request.rb
@@ -358,7 +358,7 @@ module Organizations
     # Domains win over allowlist entries (an org can have both).
     # @return [Array(Domain|nil, AllowlistEntry|nil)]
     def eligible_instruments_for!(address)
-      matched_domain = organization.domains.detect { |domain| domain.matches_email?(address) }
+      matched_domain = organization.domains.matching_email(address).first
       matched_entry = matched_domain ? nil : organization.allowlist_entries.unclaimed.for_email(address).first
 
       unless matched_domain || matched_entry

--- a/lib/organizations/models/join_request.rb
+++ b/lib/organizations/models/join_request.rb
@@ -1,0 +1,469 @@
+# frozen_string_literal: true
+
+require "digest"
+require "active_support/security_utils"
+
+module Organizations
+  # A user's petition to join an organization — the mirror image of Invitation
+  # (invitation = org→user, join request = user→org; both converge on
+  # Membership). Memberships stay active-only: all "pending" state lives here,
+  # so every existing membership invariant (counter cache, single owner,
+  # uniqueness) is untouched.
+  #
+  # Stored statuses: pending → approved | rejected | withdrawn.
+  # `:expired` is DERIVED from expires_at (same approach as invitations).
+  #
+  # A request may carry an email-verification challenge: the user proves
+  # control of an inbox that either belongs to one of the organization's
+  # Domains or matches an unclaimed AllowlistEntry. The 6-digit code is
+  # stored as a SHA-256 digest only (peppered with the row id) — plaintext
+  # never touches the database.
+  #
+  # @example Request to join (manual approval)
+  #   request = user.request_to_join!(org, message: "Soy socio nº 442")
+  #   org.approve_join_request!(request, approved_by: admin)
+  #
+  # @example Domain-email verified join
+  #   request = user.request_to_join!(org)
+  #   request.start_email_verification!(email: "j.doe@inizio.com")
+  #   request.verify_email_code!("492817") # => Membership (auto-approved)
+  #
+  class JoinRequest < ActiveRecord::Base
+    self.table_name = "organizations_join_requests"
+
+    STATUSES = %w[pending approved rejected withdrawn].freeze
+
+    # === Associations ===
+
+    belongs_to :organization,
+               class_name: "Organizations::Organization",
+               inverse_of: :join_requests
+
+    belongs_to :user
+
+    belongs_to :join_code,
+               class_name: "Organizations::JoinCode",
+               inverse_of: :join_requests,
+               optional: true
+
+    belongs_to :decided_by,
+               class_name: "User",
+               optional: true
+
+    # === Validations ===
+
+    validates :status, presence: true, inclusion: { in: STATUSES }
+    validate :unique_pending_request, on: :create
+
+    # === Callbacks ===
+
+    before_validation :set_expiry, on: :create, if: -> { expires_at.blank? }
+
+    # === Scopes ===
+
+    # Open requests (pending status and not past expiry)
+    scope :pending, -> {
+      where(status: "pending")
+        .where("expires_at IS NULL OR expires_at > ?", Time.current)
+    }
+
+    # Requests that timed out while pending
+    scope :expired, -> {
+      where(status: "pending")
+        .where("expires_at IS NOT NULL AND expires_at <= ?", Time.current)
+    }
+
+    scope :approved, -> { where(status: "approved") }
+    scope :rejected, -> { where(status: "rejected") }
+    scope :withdrawn, -> { where(status: "withdrawn") }
+
+    # === Status Methods ===
+
+    # @return [Boolean]
+    def pending?
+      status == "pending" && !expired?
+    end
+
+    # @return [Boolean]
+    def approved?
+      status == "approved"
+    end
+
+    # @return [Boolean]
+    def rejected?
+      status == "rejected"
+    end
+
+    # @return [Boolean]
+    def withdrawn?
+      status == "withdrawn"
+    end
+
+    # @return [Boolean] request timed out while pending
+    def expired?
+      status == "pending" && expires_at.present? && expires_at <= Time.current
+    end
+
+    # @return [Boolean] a terminal decision was made
+    def decided?
+      approved? || rejected? || withdrawn?
+    end
+
+    # Effective status as a symbol (derives :expired)
+    # @return [Symbol] :pending, :approved, :rejected, :withdrawn, or :expired
+    def effective_status
+      return :expired if expired?
+
+      status.to_sym
+    end
+
+    # @return [Boolean] the email challenge was completed
+    def email_verified?
+      verified_at.present?
+    end
+
+    # === Email Verification Challenge ===
+
+    # Start (or restart) the emailed-code challenge for an address the user
+    # claims to control. The address must belong to one of the organization's
+    # domains or match an unclaimed allowlist entry — proof of control is
+    # required in BOTH cases (a leaked roster must not grant membership
+    # without inbox access).
+    #
+    # @param email [String] the address to prove (may differ from user.email)
+    # @return [self]
+    # @raise [VerificationEmailNotEligible] address invalid or not eligible for this org
+    # @raise [VerificationEmailAlreadyClaimed] address already proven by another membership
+    # @raise [VerificationThrottled] resend interval / send cap hit
+    # @raise [JoinRequestExpired, JoinRequestAlreadyDecided] request not open
+    def start_email_verification!(email:)
+      address = email.to_s.strip
+
+      unless address.match?(URI::MailTo::EMAIL_REGEXP)
+        raise VerificationEmailNotEligible, "This is not a valid email address"
+      end
+
+      config = Organizations.configuration
+      normalized = config.normalize_verification_email(address)
+      code = nil
+
+      ActiveRecord::Base.transaction do
+        lock!
+        ensure_open!
+
+        matched_domain = organization.domains.detect { |domain| domain.matches_email?(address) }
+        matched_entry = matched_domain ? nil : organization.allowlist_entries.unclaimed.for_email(address).first
+
+        unless matched_domain || matched_entry
+          raise VerificationEmailNotEligible,
+                "This email address is not eligible to join this organization"
+        end
+
+        # One proven email => one membership per org. Pre-check for a friendly
+        # error; the partial unique index on memberships is the backstop.
+        if Membership.where(organization_id: organization_id, verified_email_normalized: normalized).exists?
+          raise VerificationEmailAlreadyClaimed,
+                "This email address is already associated with a member of this organization"
+        end
+
+        if verification_sends_count >= config.verification_max_sends
+          raise VerificationThrottled, "Too many codes requested for this request"
+        end
+
+        if verification_sent_at.present? && verification_sent_at > interval_ago(config.verification_resend_interval)
+          raise VerificationThrottled, "Please wait before requesting another code"
+        end
+
+        code = generate_verification_code
+
+        update!(
+          verification_email: address,
+          verification_email_normalized: normalized,
+          verification_code_digest: self.class.digest_verification_code(code, id),
+          verification_sent_at: Time.current,
+          verification_expires_at: Time.current + config.verification_code_ttl,
+          verification_attempts: 0,
+          verification_sends_count: verification_sends_count + 1,
+          verified_at: nil,
+          joined_via: joined_via.presence || (matched_domain ? "domain_email" : "allowlist"),
+          metadata: (metadata || {}).merge(
+            "matched_domain_id" => matched_domain&.id,
+            "matched_allowlist_entry_id" => matched_entry&.id
+          ).compact
+        )
+      end
+
+      deliver_verification_email(code)
+      self
+    end
+
+    # Verify the emailed code. On success, auto-approves when the governing
+    # instrument allows it (domain/roster joins: always; code joins: per the
+    # code's auto_approve flag).
+    #
+    # @param code [String] the 6-digit code as typed
+    # @return [Membership] when verification auto-approved the request
+    # @return [self] when verified but awaiting manual approval
+    # @raise [VerificationCodeInvalid, VerificationCodeExpired, VerificationAttemptsExceeded]
+    # @raise [JoinRequestExpired, JoinRequestAlreadyDecided]
+    def verify_email_code!(code)
+      config = Organizations.configuration
+      failure = nil
+
+      ActiveRecord::Base.transaction do
+        lock!
+        ensure_open!
+
+        raise VerificationCodeInvalid, "No verification code is active for this request" if verification_code_digest.blank?
+
+        if verification_attempts >= config.verification_max_attempts
+          raise VerificationAttemptsExceeded, "Too many incorrect attempts — request a new code"
+        end
+
+        if verification_expires_at.blank? || verification_expires_at <= Time.current
+          raise VerificationCodeExpired, "This code has expired — request a new one"
+        end
+
+        submitted = self.class.digest_verification_code(code.to_s.strip, id)
+
+        if ActiveSupport::SecurityUtils.secure_compare(submitted, verification_code_digest)
+          # Burn the code: single-use by construction.
+          update!(verified_at: Time.current, verification_code_digest: nil)
+        else
+          # Persist the failed attempt, then raise OUTSIDE the transaction —
+          # raising here would roll the increment back and give attackers
+          # unlimited tries.
+          update!(verification_attempts: verification_attempts + 1)
+          failure = VerificationCodeInvalid.new("The code is incorrect")
+        end
+      end
+
+      raise failure if failure
+
+      return approve!(decided_by: nil) if auto_approvable_after_verification?
+
+      self
+    end
+
+    # === Decisions ===
+
+    # Approve this request and create the membership (the ONLY way a join
+    # request becomes a membership). Row-locked and idempotent: approving an
+    # already-approved request returns the existing membership.
+    #
+    # Provenance is stamped on the membership (joined_via, verified_email,
+    # verified_at) and `membership_metadata` from the governing instruments is
+    # merged in (matched domain, then matched allowlist entry, then join code
+    # — later wins).
+    #
+    # @param decided_by [User, nil] approver (nil for auto-approvals)
+    # @return [Membership]
+    # @raise [JoinRequestExpired, JoinRequestAlreadyDecided]
+    def approve!(decided_by: nil)
+      membership = nil
+      reused_existing = false
+
+      ActiveRecord::Base.transaction do
+        lock!
+
+        if approved?
+          membership = organization.memberships.find_by(user_id: user_id)
+          raise JoinRequestAlreadyDecided, "Request was approved but the membership no longer exists" unless membership
+
+          return membership
+        end
+
+        ensure_open!
+
+        existing = organization.memberships.find_by(user_id: user_id)
+
+        if existing
+          membership = existing
+          reused_existing = true
+        else
+          membership = create_membership!
+          claim_matched_allowlist_entry!
+        end
+
+        update!(status: "approved", decided_by_id: decided_by&.id, decided_at: Time.current)
+      end
+
+      unless reused_existing
+        Callbacks.dispatch(
+          :member_joined,
+          organization: organization,
+          membership: membership,
+          user: user
+        )
+      end
+
+      Callbacks.dispatch(
+        :join_request_approved,
+        organization: organization,
+        user: user,
+        join_request: self,
+        membership: membership,
+        decided_by: decided_by
+      )
+
+      membership
+    end
+
+    # Reject this request.
+    # @param rejected_by [User, nil]
+    # @param reason [String, nil] stored in metadata for audit; never shown by the gem
+    # @return [self]
+    # @raise [JoinRequestAlreadyDecided]
+    def reject!(rejected_by: nil, reason: nil)
+      ActiveRecord::Base.transaction do
+        lock!
+        ensure_undecided!
+
+        new_metadata = (metadata || {})
+        new_metadata = new_metadata.merge("rejection_reason" => reason) if reason.present?
+
+        update!(
+          status: "rejected",
+          decided_by_id: rejected_by&.id,
+          decided_at: Time.current,
+          metadata: new_metadata
+        )
+      end
+
+      Callbacks.dispatch(
+        :join_request_rejected,
+        organization: organization,
+        user: user,
+        join_request: self,
+        decided_by: rejected_by
+      )
+
+      self
+    end
+
+    # Withdraw this request (the user cancels their own petition).
+    # @return [self]
+    # @raise [JoinRequestAlreadyDecided]
+    def withdraw!
+      ActiveRecord::Base.transaction do
+        lock!
+        ensure_undecided!
+
+        update!(status: "withdrawn", decided_at: Time.current)
+      end
+
+      self
+    end
+
+    # Digest a verification code, peppered with the row id so identical codes
+    # on different requests produce different digests.
+    # @return [String]
+    def self.digest_verification_code(code, request_id)
+      Digest::SHA256.hexdigest("#{code}-#{request_id}")
+    end
+
+    private
+
+    # Raise unless this request is still open (pending and not expired)
+    def ensure_open!
+      raise JoinRequestExpired, "This join request has expired" if expired?
+      raise JoinRequestAlreadyDecided, "This join request has already been #{status}" if decided?
+    end
+
+    # Like ensure_open! but tolerates expiry — used by reject!/withdraw! so
+    # stale requests can still be cleaned up explicitly.
+    def ensure_undecided!
+      raise JoinRequestAlreadyDecided, "This join request has already been #{status}" if decided?
+    end
+
+    def auto_approvable_after_verification?
+      return join_code.auto_approve? if join_code
+
+      true
+    end
+
+    def create_membership!
+      organization.memberships.create!(
+        user: user,
+        role: "member",
+        joined_via: joined_via.presence || "manual",
+        verified_email: email_verified? ? verification_email : nil,
+        verified_email_normalized: email_verified? ? verification_email_normalized : nil,
+        verified_at: verified_at,
+        metadata: resolved_membership_metadata
+      )
+    rescue ActiveRecord::RecordNotUnique
+      # Two possible unique collisions:
+      # 1. (user, org) membership race — another path just made them a member.
+      # 2. (org, verified_email_normalized) — the proven address was claimed
+      #    concurrently. Surface the same friendly error as the pre-check.
+      existing = organization.memberships.find_by(user_id: user_id)
+      return existing if existing
+
+      raise VerificationEmailAlreadyClaimed,
+            "This email address is already associated with a member of this organization"
+    end
+
+    def resolved_membership_metadata
+      merged = {}
+      merged = merged.merge(hashify(matched_domain&.membership_metadata))
+      merged = merged.merge(hashify(matched_allowlist_entry&.membership_metadata))
+      merged = merged.merge(hashify(join_code&.membership_metadata))
+      merged
+    end
+
+    def hashify(value)
+      value.is_a?(Hash) ? value : {}
+    end
+
+    def matched_domain
+      domain_id = (metadata || {})["matched_domain_id"]
+      return nil unless domain_id
+
+      @matched_domain ||= organization.domains.find_by(id: domain_id)
+    end
+
+    def matched_allowlist_entry
+      entry_id = (metadata || {})["matched_allowlist_entry_id"]
+      return nil unless entry_id
+
+      @matched_allowlist_entry ||= organization.allowlist_entries.find_by(id: entry_id)
+    end
+
+    def claim_matched_allowlist_entry!
+      matched_allowlist_entry&.claim!(user)
+    end
+
+    def generate_verification_code
+      format("%06d", SecureRandom.random_number(1_000_000))
+    end
+
+    def interval_ago(interval)
+      Time.current - interval
+    end
+
+    def deliver_verification_email(code)
+      mailer_class = Organizations.configuration.verification_mailer.constantize
+      mailer_class.code_email(self, code).deliver_later
+    rescue StandardError => e
+      Callbacks.log_error("[Organizations] Failed to send verification email: #{e.message}")
+    end
+
+    def set_expiry
+      expiry = Organizations.configuration.join_request_expiry
+      self.expires_at = expiry ? Time.current + expiry : nil
+    end
+
+    # Mirrors the DB partial unique index: one open request per (org, user)
+    def unique_pending_request
+      return unless organization_id && user_id
+      return unless status == "pending"
+
+      existing = JoinRequest.where(organization_id: organization_id, user_id: user_id, status: "pending")
+                            .where.not(id: id)
+                            .exists?
+
+      errors.add(:user_id, "already has a pending request for this organization") if existing
+    end
+  end
+end

--- a/lib/organizations/models/join_request.rb
+++ b/lib/organizations/models/join_request.rb
@@ -28,6 +28,10 @@ module Organizations
   #   request.start_email_verification!(email: "j.doe@inizio.com")
   #   request.verify_email_code!("492817") # => Membership (auto-approved)
   #
+  # The class carries the request's FULL lifecycle (statuses, challenge,
+  # decisions) exactly like its mirror Invitation does — splitting it would
+  # scatter one cohesive state machine across files.
+  # rubocop:disable Metrics/ClassLength
   class JoinRequest < ActiveRecord::Base
     self.table_name = "organizations_join_requests"
 
@@ -62,13 +66,13 @@ module Organizations
     # === Scopes ===
 
     # Open requests (pending status and not past expiry)
-    scope :pending, -> {
+    scope :pending, lambda {
       where(status: "pending")
         .where("expires_at IS NULL OR expires_at > ?", Time.current)
     }
 
     # Requests that timed out while pending
-    scope :expired, -> {
+    scope :expired, lambda {
       where(status: "pending")
         .where("expires_at IS NOT NULL AND expires_at <= ?", Time.current)
     }
@@ -143,54 +147,18 @@ module Organizations
         raise VerificationEmailNotEligible, "This is not a valid email address"
       end
 
-      config = Organizations.configuration
-      normalized = config.normalize_verification_email(address)
       code = nil
 
       ActiveRecord::Base.transaction do
         lock!
         ensure_open!
 
-        matched_domain = organization.domains.detect { |domain| domain.matches_email?(address) }
-        matched_entry = matched_domain ? nil : organization.allowlist_entries.unclaimed.for_email(address).first
-
-        unless matched_domain || matched_entry
-          raise VerificationEmailNotEligible,
-                "This email address is not eligible to join this organization"
-        end
-
-        # One proven email => one membership per org. Pre-check for a friendly
-        # error; the partial unique index on memberships is the backstop.
-        if Membership.where(organization_id: organization_id, verified_email_normalized: normalized).exists?
-          raise VerificationEmailAlreadyClaimed,
-                "This email address is already associated with a member of this organization"
-        end
-
-        if verification_sends_count >= config.verification_max_sends
-          raise VerificationThrottled, "Too many codes requested for this request"
-        end
-
-        if verification_sent_at.present? && verification_sent_at > interval_ago(config.verification_resend_interval)
-          raise VerificationThrottled, "Please wait before requesting another code"
-        end
+        matched_domain, matched_entry = eligible_instruments_for!(address)
+        ensure_address_unclaimed!(address)
+        ensure_send_allowed!
 
         code = generate_verification_code
-
-        update!(
-          verification_email: address,
-          verification_email_normalized: normalized,
-          verification_code_digest: self.class.digest_verification_code(code, id),
-          verification_sent_at: Time.current,
-          verification_expires_at: Time.current + config.verification_code_ttl,
-          verification_attempts: 0,
-          verification_sends_count: verification_sends_count + 1,
-          verified_at: nil,
-          joined_via: joined_via.presence || (matched_domain ? "domain_email" : "allowlist"),
-          metadata: (metadata || {}).merge(
-            "matched_domain_id" => matched_domain&.id,
-            "matched_allowlist_entry_id" => matched_entry&.id
-          ).compact
-        )
+        update!(challenge_attributes(address, code, matched_domain, matched_entry))
       end
 
       deliver_verification_email(code)
@@ -207,26 +175,14 @@ module Organizations
     # @raise [VerificationCodeInvalid, VerificationCodeExpired, VerificationAttemptsExceeded]
     # @raise [JoinRequestExpired, JoinRequestAlreadyDecided]
     def verify_email_code!(code)
-      config = Organizations.configuration
       failure = nil
 
       ActiveRecord::Base.transaction do
         lock!
         ensure_open!
+        ensure_active_challenge!
 
-        raise VerificationCodeInvalid, "No verification code is active for this request" if verification_code_digest.blank?
-
-        if verification_attempts >= config.verification_max_attempts
-          raise VerificationAttemptsExceeded, "Too many incorrect attempts — request a new code"
-        end
-
-        if verification_expires_at.blank? || verification_expires_at <= Time.current
-          raise VerificationCodeExpired, "This code has expired — request a new one"
-        end
-
-        submitted = self.class.digest_verification_code(code.to_s.strip, id)
-
-        if ActiveSupport::SecurityUtils.secure_compare(submitted, verification_code_digest)
+        if correct_code?(code)
           # Burn the code: single-use by construction.
           update!(verified_at: Time.current, verification_code_digest: nil)
         else
@@ -266,16 +222,11 @@ module Organizations
       ActiveRecord::Base.transaction do
         lock!
 
-        if approved?
-          membership = organization.memberships.find_by(user_id: user_id)
-          raise JoinRequestAlreadyDecided, "Request was approved but the membership no longer exists" unless membership
-
-          return membership
-        end
+        return approved_membership! if approved? # idempotent re-approval
 
         ensure_open!
 
-        existing = organization.memberships.find_by(user_id: user_id)
+        existing = existing_membership
 
         if existing
           membership = existing
@@ -288,24 +239,7 @@ module Organizations
         update!(status: "approved", decided_by_id: decided_by&.id, decided_at: Time.current)
       end
 
-      unless reused_existing
-        Callbacks.dispatch(
-          :member_joined,
-          organization: organization,
-          membership: membership,
-          user: user
-        )
-      end
-
-      Callbacks.dispatch(
-        :join_request_approved,
-        organization: organization,
-        user: user,
-        join_request: self,
-        membership: membership,
-        decided_by: decided_by
-      )
-
+      dispatch_approval_callbacks(membership, decided_by, reused_existing)
       membership
     end
 
@@ -319,7 +253,7 @@ module Organizations
         lock!
         ensure_undecided!
 
-        new_metadata = (metadata || {})
+        new_metadata = metadata || {}
         new_metadata = new_metadata.merge("rejection_reason" => reason) if reason.present?
 
         update!(
@@ -382,6 +316,121 @@ module Organizations
       true
     end
 
+    def existing_membership
+      organization.memberships.find_by(user_id: user_id)
+    end
+
+    # The membership behind an already-approved request (idempotent path).
+    # Raises if it was removed after approval — the request can't be reused.
+    def approved_membership!
+      membership = existing_membership
+      raise JoinRequestAlreadyDecided, "Request was approved but the membership no longer exists" unless membership
+
+      membership
+    end
+
+    # Post-approval callback dispatches (outside the approval transaction).
+    # member_joined is skipped when the membership pre-existed via another
+    # path — it already fired when that membership was created.
+    def dispatch_approval_callbacks(membership, decided_by, reused_existing)
+      unless reused_existing
+        Callbacks.dispatch(
+          :member_joined,
+          organization: organization,
+          membership: membership,
+          user: user
+        )
+      end
+
+      Callbacks.dispatch(
+        :join_request_approved,
+        organization: organization,
+        user: user,
+        join_request: self,
+        membership: membership,
+        decided_by: decided_by
+      )
+    end
+
+    # === Challenge guards & builders (all called under lock) ===
+
+    # Resolve which join instrument makes this address eligible.
+    # Domains win over allowlist entries (an org can have both).
+    # @return [Array(Domain|nil, AllowlistEntry|nil)]
+    def eligible_instruments_for!(address)
+      matched_domain = organization.domains.detect { |domain| domain.matches_email?(address) }
+      matched_entry = matched_domain ? nil : organization.allowlist_entries.unclaimed.for_email(address).first
+
+      unless matched_domain || matched_entry
+        raise VerificationEmailNotEligible,
+              "This email address is not eligible to join this organization"
+      end
+
+      [matched_domain, matched_entry]
+    end
+
+    # One proven email => one membership per org. Pre-check for a friendly
+    # error; the unique index on memberships is the backstop.
+    def ensure_address_unclaimed!(address)
+      normalized = Organizations.configuration.normalize_verification_email(address)
+      return unless Membership.where(organization_id: organization_id, verified_email_normalized: normalized).exists?
+
+      raise VerificationEmailAlreadyClaimed,
+            "This email address is already associated with a member of this organization"
+    end
+
+    def ensure_send_allowed!
+      config = Organizations.configuration
+
+      if verification_sends_count >= config.verification_max_sends
+        raise VerificationThrottled, "Too many codes requested for this request"
+      end
+
+      resend_floor = interval_ago(config.verification_resend_interval)
+      return unless verification_sent_at.present? && verification_sent_at > resend_floor
+
+      raise VerificationThrottled, "Please wait before requesting another code"
+    end
+
+    def ensure_active_challenge!
+      config = Organizations.configuration
+
+      raise VerificationCodeInvalid, "No verification code is active for this request" if verification_code_digest.blank?
+
+      if verification_attempts >= config.verification_max_attempts
+        raise VerificationAttemptsExceeded, "Too many incorrect attempts — request a new code"
+      end
+
+      return unless verification_expires_at.blank? || verification_expires_at <= Time.current
+
+      raise VerificationCodeExpired, "This code has expired — request a new one"
+    end
+
+    def correct_code?(code)
+      submitted = self.class.digest_verification_code(code.to_s.strip, id)
+      ActiveSupport::SecurityUtils.secure_compare(submitted, verification_code_digest)
+    end
+
+    def challenge_attributes(address, code, matched_domain, matched_entry)
+      config = Organizations.configuration
+
+      {
+        verification_email: address,
+        verification_email_normalized: config.normalize_verification_email(address),
+        verification_code_digest: self.class.digest_verification_code(code, id),
+        verification_sent_at: Time.current,
+        verification_expires_at: Time.current + config.verification_code_ttl,
+        verification_attempts: 0,
+        verification_sends_count: verification_sends_count + 1,
+        verified_at: nil,
+        joined_via: joined_via.presence || (matched_domain ? "domain_email" : "allowlist"),
+        metadata: (metadata || {}).merge(
+          "matched_domain_id" => matched_domain&.id,
+          "matched_allowlist_entry_id" => matched_entry&.id
+        ).compact
+      }
+    end
+
     def create_membership!
       organization.memberships.create!(
         user: user,
@@ -408,8 +457,7 @@ module Organizations
       merged = {}
       merged = merged.merge(hashify(matched_domain&.membership_metadata))
       merged = merged.merge(hashify(matched_allowlist_entry&.membership_metadata))
-      merged = merged.merge(hashify(join_code&.membership_metadata))
-      merged
+      merged.merge(hashify(join_code&.membership_metadata))
     end
 
     def hashify(value)
@@ -460,10 +508,11 @@ module Organizations
       return unless status == "pending"
 
       existing = JoinRequest.where(organization_id: organization_id, user_id: user_id, status: "pending")
-                            .where.not(id: id)
-                            .exists?
+        .where.not(id: id)
+        .exists?
 
       errors.add(:user_id, "already has a pending request for this organization") if existing
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/organizations/models/membership.rb
+++ b/lib/organizations/models/membership.rb
@@ -71,6 +71,15 @@ module Organizations
       SQL
     }
 
+    # === Verified Joining (v0.5.0) ===
+
+    # Whether this membership was created with a proven email address
+    # (emailed-code challenge, confirmed account email, or accepted invitation)
+    # @return [Boolean]
+    def verified?
+      verified_at.present?
+    end
+
     # === Role Methods ===
 
     # Get the role as a symbol

--- a/lib/organizations/models/organization.rb
+++ b/lib/organizations/models/organization.rb
@@ -502,7 +502,7 @@ module Organizations
         raise VerificationEmailNotEligible, "The account email has not been confirmed"
       end
 
-      matched_domain = domains.detect { |domain| domain.matches_email?(email) }
+      matched_domain = domains.matching_email(email).first
       unless matched_domain
         raise VerificationEmailNotEligible, "This email address is not eligible to join this organization"
       end

--- a/lib/organizations/models/organization.rb
+++ b/lib/organizations/models/organization.rb
@@ -43,6 +43,28 @@ module Organizations
              inverse_of: :organization,
              dependent: :destroy
 
+    # === Verified joining (v0.5.0) ===
+
+    has_many :domains,
+             class_name: "Organizations::Domain",
+             inverse_of: :organization,
+             dependent: :destroy
+
+    has_many :join_codes,
+             class_name: "Organizations::JoinCode",
+             inverse_of: :organization,
+             dependent: :destroy
+
+    has_many :allowlist_entries,
+             class_name: "Organizations::AllowlistEntry",
+             inverse_of: :organization,
+             dependent: :destroy
+
+    has_many :join_requests,
+             class_name: "Organizations::JoinRequest",
+             inverse_of: :organization,
+             dependent: :destroy
+
     # === Validations ===
 
     validates :name, presence: true
@@ -370,7 +392,156 @@ module Organizations
       invitations.pending.for_email(normalized_email).first!
     end
 
+    # === Verified Joining Methods (v0.5.0) ===
+
+    # Enroll an email domain for domain-verified joining.
+    # @param domain [String] e.g. "inizio.com" (exact match — subdomains must be enrolled separately)
+    # @param membership_metadata [Hash] copied onto memberships created through this domain
+    # @return [Domain]
+    def add_domain!(domain, membership_metadata: {})
+      domains.create!(domain: domain, membership_metadata: membership_metadata)
+    end
+
+    # Generate a shareable join code (PIN).
+    # @param label [String, nil] campaign attribution ("cafeteria poster")
+    # @param requires_verified_domain_email [Boolean] chain the emailed-code challenge ("reinforced" level)
+    # @param auto_approve [Boolean] false parks redemptions as pending requests for manual approval
+    # @param expires_at [Time, nil]
+    # @param max_uses [Integer, nil]
+    # @param created_by [User, nil]
+    # @param membership_metadata [Hash] copied onto memberships created through this code
+    # @return [JoinCode]
+    def generate_join_code!(label: nil, requires_verified_domain_email: false, auto_approve: true,
+                            expires_at: nil, max_uses: nil, created_by: nil, membership_metadata: {})
+      join_codes.create!(
+        label: label,
+        requires_verified_domain_email: requires_verified_domain_email,
+        auto_approve: auto_approve,
+        expires_at: expires_at,
+        max_uses: max_uses,
+        created_by_id: created_by&.id,
+        membership_metadata: membership_metadata
+      )
+    end
+
+    # Bulk-import roster emails as allowlist entries (idempotent per address:
+    # already-enrolled addresses are skipped, not duplicated).
+    # @param emails [Enumerable<String>]
+    # @param source [String, nil] provenance tag ("csv_2026-07")
+    # @param membership_metadata [Hash] copied onto memberships created through these entries
+    # @return [Array<AllowlistEntry>] the newly created entries
+    def import_allowlist!(emails, source: nil, membership_metadata: {})
+      Array(emails).filter_map do |email|
+        entry = allowlist_entries.create!(
+          email: email,
+          source: source,
+          membership_metadata: membership_metadata
+        )
+        entry
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+        # Skip duplicates silently (idempotent import); re-raise anything else.
+        raise e unless duplicate_allowlist_error?(e)
+
+        nil
+      end
+    end
+
+    # Open join requests awaiting a decision
+    # @return [ActiveRecord::Relation<JoinRequest>]
+    def pending_join_requests
+      join_requests.pending
+    end
+
+    # Whether this organization exposes any self-serve joining mechanism
+    # @return [Boolean]
+    def accepts_join_requests?
+      domains.exists? || join_codes.not_revoked.exists? || allowlist_entries.unclaimed.exists?
+    end
+
+    # Approve a join request (creates the membership). See JoinRequest#approve!.
+    # @param join_request [JoinRequest]
+    # @param approved_by [User, nil]
+    # @return [Membership]
+    def approve_join_request!(join_request, approved_by: nil)
+      ensure_join_request_belongs_here!(join_request)
+      join_request.approve!(decided_by: approved_by)
+    end
+
+    # Reject a join request. See JoinRequest#reject!.
+    # @param join_request [JoinRequest]
+    # @param rejected_by [User, nil]
+    # @param reason [String, nil]
+    # @return [JoinRequest]
+    def reject_join_request!(join_request, rejected_by: nil, reason: nil)
+      ensure_join_request_belongs_here!(join_request)
+      join_request.reject!(rejected_by: rejected_by, reason: reason)
+    end
+
+    # Zero-friction domain join for hosts with confirmed account emails
+    # (e.g. Devise :confirmable): if the user's own account email is confirmed
+    # and its domain is enrolled, the inbox was already proven at signup — no
+    # emailed code needed.
+    #
+    # @param user [User] must respond to #email; #confirmed_at gates trust
+    # @return [Membership]
+    # @raise [VerificationEmailNotEligible] when the account email's domain isn't enrolled,
+    #   the email is unconfirmed, or the feature is disabled
+    def join_with_account_email!(user)
+      unless Organizations.configuration.trust_confirmed_account_email
+        raise VerificationEmailNotEligible, "Account-email trust is disabled (see config.trust_confirmed_account_email)"
+      end
+
+      email = user.respond_to?(:email) ? user.email.to_s : ""
+      confirmed = user.respond_to?(:confirmed_at) && user.confirmed_at.present?
+
+      unless confirmed
+        raise VerificationEmailNotEligible, "The account email has not been confirmed"
+      end
+
+      matched_domain = domains.detect { |domain| domain.matches_email?(email) }
+      unless matched_domain
+        raise VerificationEmailNotEligible, "This email address is not eligible to join this organization"
+      end
+
+      # Uniform funnel: every self-serve join goes through a JoinRequest so
+      # provenance and audit trail come for free.
+      request = join_requests.pending.find_by(user_id: user.id) || join_requests.new(user: user)
+      normalized = Organizations.configuration.normalize_verification_email(email)
+
+      ActiveRecord::Base.transaction do
+        if Membership.where(organization_id: id, verified_email_normalized: normalized).exists?
+          raise VerificationEmailAlreadyClaimed,
+                "This email address is already associated with a member of this organization"
+        end
+
+        request.assign_attributes(
+          joined_via: "domain_email",
+          verification_email: email,
+          verification_email_normalized: normalized,
+          verified_at: Time.current,
+          metadata: (request.metadata || {}).merge("matched_domain_id" => matched_domain.id)
+        )
+        request.save!
+      end
+
+      request.approve!(decided_by: nil)
+    end
+
     private
+
+    def ensure_join_request_belongs_here!(join_request)
+      return if join_request.organization_id == id
+
+      raise ArgumentError, "Join request does not belong to this organization"
+    end
+
+    def duplicate_allowlist_error?(error)
+      return true if error.is_a?(ActiveRecord::RecordNotUnique)
+
+      error.is_a?(ActiveRecord::RecordInvalid) &&
+        error.record.is_a?(Organizations::AllowlistEntry) &&
+        error.record.errors.of_kind?(:email_normalized, :taken)
+    end
 
     # Defense in depth for organization-centric API usage.
     # The user-level API already checks this, but direct calls to `org.send_invite_to!`

--- a/lib/organizations/models/organization.rb
+++ b/lib/organizations/models/organization.rb
@@ -411,6 +411,9 @@ module Organizations
     # @param created_by [User, nil]
     # @param membership_metadata [Hash] copied onto memberships created through this code
     # @return [JoinCode]
+    # Every parameter is an optional keyword with a safe default — this IS
+    # the public API surface, not incidental complexity.
+    # rubocop:disable Metrics/ParameterLists
     def generate_join_code!(label: nil, requires_verified_domain_email: false, auto_approve: true,
                             expires_at: nil, max_uses: nil, created_by: nil, membership_metadata: {})
       join_codes.create!(
@@ -423,6 +426,7 @@ module Organizations
         membership_metadata: membership_metadata
       )
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # Bulk-import roster emails as allowlist entries (idempotent per address:
     # already-enrolled addresses are skipped, not duplicated).

--- a/lib/organizations/version.rb
+++ b/lib/organizations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Organizations
-  VERSION = "0.4.3"
+  VERSION = "0.5.0"
 end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -71,7 +71,7 @@ module Organizations
 
     # ── EVENTS constant ──────────────────────────────────────────────────
 
-    test "EVENTS contains all six lifecycle events" do
+    test "EVENTS contains all lifecycle events" do
       expected = %i[
         organization_created
         member_invited
@@ -79,6 +79,9 @@ module Organizations
         member_removed
         role_changed
         ownership_transferred
+        join_request_created
+        join_request_approved
+        join_request_rejected
       ]
       assert_equal expected, Callbacks::EVENTS
     end
@@ -387,6 +390,9 @@ module Organizations
         config.on_member_removed { procs[:removed] = true }
         config.on_role_changed { procs[:role] = true }
         config.on_ownership_transferred { procs[:transfer] = true }
+        config.on_join_request_created { procs[:jr_created] = true }
+        config.on_join_request_approved { procs[:jr_approved] = true }
+        config.on_join_request_rejected { procs[:jr_rejected] = true }
       end
 
       Callbacks::EVENTS.each do |event|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -19,6 +19,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_000002) do
     t.string "role", default: "member", null: false
     t.datetime "accepted_at"
     t.datetime "expires_at"
+    t.json "metadata", default: {}, null: false
+    t.json "membership_metadata", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index "organization_id, LOWER(email)", name: "index_organizations_invitations_pending_unique", unique: true, where: "accepted_at IS NULL"
@@ -34,9 +36,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_000002) do
     t.bigint "invited_by_id"
     t.string "role", default: "member", null: false
     t.json "metadata", default: {}, null: false
+    t.string "joined_via"
+    t.string "verified_email"
+    t.string "verified_email_normalized"
+    t.datetime "verified_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["invited_by_id"], name: "index_organizations_memberships_on_invited_by_id"
+    t.index ["organization_id", "verified_email_normalized"], name: "index_org_memberships_verified_email_unique", unique: true
     t.index ["organization_id"], name: "index_organizations_memberships_on_organization_id"
     t.index ["organization_id"], name: "index_organizations_memberships_single_owner", unique: true, where: "role = 'owner'"
     t.index ["role"], name: "index_organizations_memberships_on_role"
@@ -52,6 +59,83 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_000002) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "organizations_domains", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.string "domain", null: false
+    t.json "membership_metadata", default: {}, null: false
+    t.json "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["domain"], name: "index_organizations_domains_on_domain"
+    t.index ["organization_id", "domain"], name: "index_organizations_domains_on_organization_id_and_domain", unique: true
+    t.index ["organization_id"], name: "index_organizations_domains_on_organization_id"
+  end
+
+  create_table "organizations_join_codes", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.string "code", null: false
+    t.string "label"
+    t.boolean "requires_verified_domain_email", default: false, null: false
+    t.boolean "auto_approve", default: true, null: false
+    t.datetime "expires_at"
+    t.integer "max_uses"
+    t.integer "uses_count", default: 0, null: false
+    t.datetime "revoked_at"
+    t.bigint "created_by_id"
+    t.json "membership_metadata", default: {}, null: false
+    t.json "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_organizations_join_codes_on_code", unique: true
+    t.index ["created_by_id"], name: "index_organizations_join_codes_on_created_by_id"
+    t.index ["organization_id"], name: "index_organizations_join_codes_on_organization_id"
+  end
+
+  create_table "organizations_allowlist_entries", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.string "email", null: false
+    t.string "email_normalized", null: false
+    t.string "source"
+    t.json "membership_metadata", default: {}, null: false
+    t.datetime "claimed_at"
+    t.bigint "claimed_by_id"
+    t.json "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["claimed_by_id"], name: "index_organizations_allowlist_entries_on_claimed_by_id"
+    t.index ["organization_id", "email_normalized"], name: "idx_org_allowlist_entries_on_org_and_email_normalized", unique: true
+    t.index ["organization_id"], name: "index_organizations_allowlist_entries_on_organization_id"
+  end
+
+  create_table "organizations_join_requests", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.bigint "user_id", null: false
+    t.string "status", default: "pending", null: false
+    t.string "joined_via"
+    t.bigint "join_code_id"
+    t.string "message"
+    t.string "verification_email"
+    t.string "verification_email_normalized"
+    t.string "verification_code_digest"
+    t.datetime "verification_sent_at"
+    t.datetime "verification_expires_at"
+    t.integer "verification_attempts", default: 0, null: false
+    t.integer "verification_sends_count", default: 0, null: false
+    t.datetime "verified_at"
+    t.bigint "decided_by_id"
+    t.datetime "decided_at"
+    t.datetime "expires_at"
+    t.json "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decided_by_id"], name: "index_organizations_join_requests_on_decided_by_id"
+    t.index ["join_code_id"], name: "index_organizations_join_requests_on_join_code_id"
+    t.index ["organization_id", "user_id"], name: "index_org_join_requests_pending_unique", unique: true, where: "status = 'pending'"
+    t.index ["organization_id"], name: "index_organizations_join_requests_on_organization_id"
+    t.index ["status"], name: "index_organizations_join_requests_on_status"
+    t.index ["user_id"], name: "index_organizations_join_requests_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "name"
@@ -64,4 +148,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_000002) do
   add_foreign_key "organizations_memberships", "organizations_organizations", column: "organization_id"
   add_foreign_key "organizations_memberships", "users"
   add_foreign_key "organizations_memberships", "users", column: "invited_by_id"
+  add_foreign_key "organizations_domains", "organizations_organizations", column: "organization_id"
+  add_foreign_key "organizations_join_codes", "organizations_organizations", column: "organization_id"
+  add_foreign_key "organizations_join_codes", "users", column: "created_by_id"
+  add_foreign_key "organizations_allowlist_entries", "organizations_organizations", column: "organization_id"
+  add_foreign_key "organizations_allowlist_entries", "users", column: "claimed_by_id"
+  add_foreign_key "organizations_join_requests", "organizations_organizations", column: "organization_id"
+  add_foreign_key "organizations_join_requests", "organizations_join_codes", column: "join_code_id"
+  add_foreign_key "organizations_join_requests", "users"
+  add_foreign_key "organizations_join_requests", "users", column: "decided_by_id"
 end

--- a/test/email_normalizer_test.rb
+++ b/test/email_normalizer_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organizations
+  class EmailNormalizerTest < Organizations::Test
+    # =========================================================================
+    # normalize
+    # =========================================================================
+
+    test "downcases and strips whitespace" do
+      assert_equal "j.doe@inizio.com", EmailNormalizer.normalize("  J.Doe@INIZIO.COM  ")
+    end
+
+    test "strips plus-tag from the local part" do
+      assert_equal "j.doe@inizio.com", EmailNormalizer.normalize("j.doe+carpool@inizio.com")
+    end
+
+    test "strips everything after the first plus" do
+      assert_equal "j.doe@inizio.com", EmailNormalizer.normalize("j.doe+a+b+c@inizio.com")
+    end
+
+    test "strips a trailing dot from the domain (FQDN form)" do
+      assert_equal "j.doe@inizio.com", EmailNormalizer.normalize("j.doe@inizio.com.")
+    end
+
+    test "the full E3 collapse: case + plus-tag + FQDN dot at once" do
+      assert_equal "j.doe@inizio.com", EmailNormalizer.normalize("  J.Doe+carpool@INIZIO.COM. ")
+    end
+
+    test "does NOT collapse dots in the local part (corporate mailboxes differ)" do
+      refute_equal EmailNormalizer.normalize("j.doe@inizio.com"),
+                   EmailNormalizer.normalize("jdoe@inizio.com")
+    end
+
+    test "returns empty string for blank input" do
+      assert_equal "", EmailNormalizer.normalize(nil)
+      assert_equal "", EmailNormalizer.normalize("")
+      assert_equal "", EmailNormalizer.normalize("   ")
+    end
+
+    test "leaves non-email shapes as-is (validation rejects them upstream)" do
+      assert_equal "not-an-email", EmailNormalizer.normalize("Not-An-Email")
+    end
+
+    test "plus-tagged aliases collapse to the same normalized value" do
+      a = EmailNormalizer.normalize("ana+1@iberozoa.com")
+      b = EmailNormalizer.normalize("ana+2@iberozoa.com")
+      c = EmailNormalizer.normalize("ana@iberozoa.com")
+      assert_equal a, b
+      assert_equal b, c
+    end
+
+    # =========================================================================
+    # domain_of
+    # =========================================================================
+
+    test "extracts the domain, lowercased" do
+      assert_equal "inizio.com", EmailNormalizer.domain_of("J.Doe@INIZIO.COM")
+    end
+
+    test "tolerates and strips a single trailing dot" do
+      assert_equal "inizio.com", EmailNormalizer.domain_of("j@inizio.com.")
+    end
+
+    test "rejects multi-@ evasion shapes (E4)" do
+      assert_nil EmailNormalizer.domain_of("evil@a.com@b.com")
+      assert_nil EmailNormalizer.domain_of("a@b@c@d.com")
+    end
+
+    test "returns nil for blank or @-less input" do
+      assert_nil EmailNormalizer.domain_of(nil)
+      assert_nil EmailNormalizer.domain_of("")
+      assert_nil EmailNormalizer.domain_of("no-at-sign")
+    end
+
+    test "returns nil when the domain part is empty" do
+      assert_nil EmailNormalizer.domain_of("user@")
+      assert_nil EmailNormalizer.domain_of("user@.")
+    end
+
+    test "lookalike suffix domains do NOT equal the real domain (E4)" do
+      refute_equal "urjc.es", EmailNormalizer.domain_of("x@urjc.es.evil.com")
+      refute_equal "urjc.es", EmailNormalizer.domain_of("x@evilurjc.es")
+    end
+  end
+end

--- a/test/email_normalizer_test.rb
+++ b/test/email_normalizer_test.rb
@@ -47,6 +47,7 @@ module Organizations
       a = EmailNormalizer.normalize("ana+1@iberozoa.com")
       b = EmailNormalizer.normalize("ana+2@iberozoa.com")
       c = EmailNormalizer.normalize("ana@iberozoa.com")
+
       assert_equal a, b
       assert_equal b, c
     end

--- a/test/models/allowlist_entry_test.rb
+++ b/test/models/allowlist_entry_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organizations
+  class AllowlistEntryTest < Organizations::Test
+    def setup
+      super
+      @org, @owner = create_org_with_owner!(name: "Iberozoa")
+      @user = create_user!(email: "ana.personal@gmail.com", name: "Ana")
+    end
+
+    test "table_name is organizations_allowlist_entries" do
+      assert_equal "organizations_allowlist_entries", Organizations::AllowlistEntry.table_name
+    end
+
+    # =========================================================================
+    # Creation & normalization
+    # =========================================================================
+
+    test "stores the email as provided and a normalized twin" do
+      entry = @org.allowlist_entries.create!(email: "Ana+Socia@Gmail.com")
+      assert_equal "Ana+Socia@Gmail.com", entry.email
+      assert_equal "ana@gmail.com", entry.email_normalized
+    end
+
+    test "rejects invalid email shapes" do
+      assert_raises(ActiveRecord::RecordInvalid) { @org.allowlist_entries.create!(email: "not-an-email") }
+    end
+
+    test "unique per organization on the NORMALIZED form (plus-tag aliases collide)" do
+      @org.allowlist_entries.create!(email: "ana@gmail.com")
+      assert_raises(ActiveRecord::RecordInvalid) { @org.allowlist_entries.create!(email: "ANA+bis@gmail.com") }
+    end
+
+    test "the same email can be rostered by two different organizations" do
+      other_org, = create_org_with_owner!(name: "Other")
+      @org.allowlist_entries.create!(email: "ana@gmail.com")
+      assert other_org.allowlist_entries.create!(email: "ana@gmail.com").persisted?
+    end
+
+    # =========================================================================
+    # import_allowlist!
+    # =========================================================================
+
+    test "import_allowlist! bulk-creates entries with source and metadata" do
+      entries = @org.import_allowlist!(
+        ["ana@gmail.com", "luis@yahoo.es"],
+        source: "csv_2026-07",
+        membership_metadata: { member_kind: "member" }
+      )
+
+      assert_equal 2, entries.size
+      assert entries.all? { |e| e.source == "csv_2026-07" }
+      assert_equal "member", entries.first.membership_metadata["member_kind"] || entries.first.membership_metadata[:member_kind]
+    end
+
+    test "import_allowlist! is idempotent — duplicates are skipped, not duplicated" do
+      @org.import_allowlist!(["ana@gmail.com"])
+      created = @org.import_allowlist!(["ana@gmail.com", "nuevo@gmail.com"])
+
+      assert_equal ["nuevo@gmail.com"], created.map(&:email)
+      assert_equal 2, @org.allowlist_entries.count
+    end
+
+    test "import_allowlist! raises loudly on invalid addresses (bad CSV rows must not vanish silently)" do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @org.import_allowlist!(["ok@gmail.com", "broken-row"])
+      end
+    end
+
+    # =========================================================================
+    # Scopes & claiming
+    # =========================================================================
+
+    test "for_email matches through the normalizer" do
+      entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
+      assert_equal [entry], @org.allowlist_entries.for_email("ANA+x@gmail.com").to_a
+    end
+
+    test "unclaimed excludes claimed entries" do
+      entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
+      assert_includes @org.allowlist_entries.unclaimed, entry
+
+      entry.claim!(@user)
+      assert_empty @org.allowlist_entries.unclaimed
+    end
+
+    test "claim! stamps claimed_at and claimed_by" do
+      entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
+      entry.claim!(@user)
+
+      assert entry.claimed?
+      assert_equal @user, entry.claimed_by
+      assert_not_nil entry.claimed_at
+    end
+
+    test "claim! is idempotent — second claim does not steal the entry" do
+      other = create_user!(email: "other@gmail.com")
+      entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
+
+      entry.claim!(@user)
+      first_claimed_at = entry.claimed_at
+      entry.claim!(other)
+
+      assert_equal @user, entry.reload.claimed_by
+      assert_equal first_claimed_at.to_i, entry.claimed_at.to_i
+    end
+  end
+end

--- a/test/models/allowlist_entry_test.rb
+++ b/test/models/allowlist_entry_test.rb
@@ -20,6 +20,7 @@ module Organizations
 
     test "stores the email as provided and a normalized twin" do
       entry = @org.allowlist_entries.create!(email: "Ana+Socia@Gmail.com")
+
       assert_equal "Ana+Socia@Gmail.com", entry.email
       assert_equal "ana@gmail.com", entry.email_normalized
     end
@@ -36,7 +37,8 @@ module Organizations
     test "the same email can be rostered by two different organizations" do
       other_org, = create_org_with_owner!(name: "Other")
       @org.allowlist_entries.create!(email: "ana@gmail.com")
-      assert other_org.allowlist_entries.create!(email: "ana@gmail.com").persisted?
+
+      assert_predicate other_org.allowlist_entries.create!(email: "ana@gmail.com"), :persisted?
     end
 
     # =========================================================================
@@ -51,8 +53,9 @@ module Organizations
       )
 
       assert_equal 2, entries.size
-      assert entries.all? { |e| e.source == "csv_2026-07" }
-      assert_equal "member", entries.first.membership_metadata["member_kind"] || entries.first.membership_metadata[:member_kind]
+      assert(entries.all? { |e| e.source == "csv_2026-07" })
+      assert_equal "member",
+                   entries.first.membership_metadata["member_kind"] || entries.first.membership_metadata[:member_kind]
     end
 
     test "import_allowlist! is idempotent — duplicates are skipped, not duplicated" do
@@ -75,14 +78,17 @@ module Organizations
 
     test "for_email matches through the normalizer" do
       entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
+
       assert_equal [entry], @org.allowlist_entries.for_email("ANA+x@gmail.com").to_a
     end
 
     test "unclaimed excludes claimed entries" do
       entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
+
       assert_includes @org.allowlist_entries.unclaimed, entry
 
       entry.claim!(@user)
+
       assert_empty @org.allowlist_entries.unclaimed
     end
 
@@ -90,7 +96,7 @@ module Organizations
       entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
       entry.claim!(@user)
 
-      assert entry.claimed?
+      assert_predicate entry, :claimed?
       assert_equal @user, entry.claimed_by
       assert_not_nil entry.claimed_at
     end

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -19,18 +19,21 @@ module Organizations
 
     test "add_domain! creates a domain on the organization" do
       domain = @org.add_domain!("inizio.com")
-      assert domain.persisted?
+
+      assert_predicate domain, :persisted?
       assert_equal @org, domain.organization
       assert_equal "inizio.com", domain.domain
     end
 
     test "normalizes case, whitespace, leading @ and trailing dot" do
       domain = @org.add_domain!("  @INIZIO.COM.  ")
+
       assert_equal "inizio.com", domain.domain
     end
 
     test "add_domain! carries membership_metadata (cohort copy-through source)" do
       domain = @org.add_domain!("alumnos.urjc.es", membership_metadata: { member_kind: "student" })
+
       assert_equal "student", domain.membership_metadata["member_kind"] || domain.membership_metadata[:member_kind]
     end
 
@@ -58,7 +61,8 @@ module Organizations
     test "the same domain can be enrolled by two different organizations" do
       other_org, = create_org_with_owner!(name: "Other")
       @org.add_domain!("shared.es")
-      assert other_org.add_domain!("shared.es").persisted?
+
+      assert_predicate other_org.add_domain!("shared.es"), :persisted?
     end
 
     # =========================================================================
@@ -67,28 +71,33 @@ module Organizations
 
     test "matches_email? is exact" do
       domain = @org.add_domain!("urjc.es")
+
       assert domain.matches_email?("prof@urjc.es")
       assert domain.matches_email?("PROF@URJC.ES")
     end
 
     test "matches_email? does NOT match subdomains (E8 — different cohorts)" do
       domain = @org.add_domain!("urjc.es")
+
       refute domain.matches_email?("student@alumnos.urjc.es")
     end
 
     test "matches_email? rejects lookalike suffixes (E4)" do
       domain = @org.add_domain!("urjc.es")
+
       refute domain.matches_email?("x@urjc.es.evil.com")
       refute domain.matches_email?("x@evilurjc.es")
     end
 
     test "matches_email? rejects multi-@ evasion (E4)" do
       domain = @org.add_domain!("urjc.es")
+
       refute domain.matches_email?("x@urjc.es@evil.com")
     end
 
     test "matches_email? tolerates trailing-dot FQDN form" do
       domain = @org.add_domain!("urjc.es")
+
       assert domain.matches_email?("prof@urjc.es.")
     end
 
@@ -98,11 +107,13 @@ module Organizations
       d2 = other_org.add_domain!("shared.es")
 
       matches = Organizations::Domain.matching_email("someone@shared.es")
+
       assert_equal [d1.id, d2.id].sort, matches.map(&:id).sort
     end
 
     test "matching_email scope returns none for evasion shapes" do
       @org.add_domain!("urjc.es")
+
       assert_empty Organizations::Domain.matching_email("x@urjc.es@evil.com")
       assert_empty Organizations::Domain.matching_email("")
     end
@@ -110,6 +121,7 @@ module Organizations
     test "destroyed with the organization" do
       @org.add_domain!("inizio.com")
       @org.destroy!
+
       assert_equal 0, Organizations::Domain.count
     end
   end

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organizations
+  class DomainTest < Organizations::Test
+    def setup
+      super
+      @org, @owner = create_org_with_owner!(name: "Inizio")
+    end
+
+    test "table_name is organizations_domains" do
+      assert_equal "organizations_domains", Organizations::Domain.table_name
+    end
+
+    # =========================================================================
+    # Creation & normalization
+    # =========================================================================
+
+    test "add_domain! creates a domain on the organization" do
+      domain = @org.add_domain!("inizio.com")
+      assert domain.persisted?
+      assert_equal @org, domain.organization
+      assert_equal "inizio.com", domain.domain
+    end
+
+    test "normalizes case, whitespace, leading @ and trailing dot" do
+      domain = @org.add_domain!("  @INIZIO.COM.  ")
+      assert_equal "inizio.com", domain.domain
+    end
+
+    test "add_domain! carries membership_metadata (cohort copy-through source)" do
+      domain = @org.add_domain!("alumnos.urjc.es", membership_metadata: { member_kind: "student" })
+      assert_equal "student", domain.membership_metadata["member_kind"] || domain.membership_metadata[:member_kind]
+    end
+
+    test "rejects blank domains" do
+      assert_raises(ActiveRecord::RecordInvalid) { @org.add_domain!("") }
+    end
+
+    test "rejects domains without a dot" do
+      assert_raises(ActiveRecord::RecordInvalid) { @org.add_domain!("localhost") }
+    end
+
+    test "rejects domains with an @ inside" do
+      assert_raises(ActiveRecord::RecordInvalid) { @org.add_domain!("user@inizio.com") }
+    end
+
+    test "rejects domains with spaces" do
+      assert_raises(ActiveRecord::RecordInvalid) { @org.add_domain!("inizio .com") }
+    end
+
+    test "is unique per organization (case-insensitive via normalization)" do
+      @org.add_domain!("inizio.com")
+      assert_raises(ActiveRecord::RecordInvalid) { @org.add_domain!("INIZIO.com") }
+    end
+
+    test "the same domain can be enrolled by two different organizations" do
+      other_org, = create_org_with_owner!(name: "Other")
+      @org.add_domain!("shared.es")
+      assert other_org.add_domain!("shared.es").persisted?
+    end
+
+    # =========================================================================
+    # Matching (exact, dot-boundary safe)
+    # =========================================================================
+
+    test "matches_email? is exact" do
+      domain = @org.add_domain!("urjc.es")
+      assert domain.matches_email?("prof@urjc.es")
+      assert domain.matches_email?("PROF@URJC.ES")
+    end
+
+    test "matches_email? does NOT match subdomains (E8 — different cohorts)" do
+      domain = @org.add_domain!("urjc.es")
+      refute domain.matches_email?("student@alumnos.urjc.es")
+    end
+
+    test "matches_email? rejects lookalike suffixes (E4)" do
+      domain = @org.add_domain!("urjc.es")
+      refute domain.matches_email?("x@urjc.es.evil.com")
+      refute domain.matches_email?("x@evilurjc.es")
+    end
+
+    test "matches_email? rejects multi-@ evasion (E4)" do
+      domain = @org.add_domain!("urjc.es")
+      refute domain.matches_email?("x@urjc.es@evil.com")
+    end
+
+    test "matches_email? tolerates trailing-dot FQDN form" do
+      domain = @org.add_domain!("urjc.es")
+      assert domain.matches_email?("prof@urjc.es.")
+    end
+
+    test "matching_email scope finds candidate org domains across organizations" do
+      d1 = @org.add_domain!("shared.es")
+      other_org, = create_org_with_owner!(name: "Other")
+      d2 = other_org.add_domain!("shared.es")
+
+      matches = Organizations::Domain.matching_email("someone@shared.es")
+      assert_equal [d1.id, d2.id].sort, matches.map(&:id).sort
+    end
+
+    test "matching_email scope returns none for evasion shapes" do
+      @org.add_domain!("urjc.es")
+      assert_empty Organizations::Domain.matching_email("x@urjc.es@evil.com")
+      assert_empty Organizations::Domain.matching_email("")
+    end
+
+    test "destroyed with the organization" do
+      @org.add_domain!("inizio.com")
+      @org.destroy!
+      assert_equal 0, Organizations::Domain.count
+    end
+  end
+end

--- a/test/models/invitation_provenance_test.rb
+++ b/test/models/invitation_provenance_test.rb
@@ -21,13 +21,14 @@ module Organizations
       membership = invite!.accept!(@invitee)
 
       assert_equal "invited", membership.joined_via
-      assert membership.verified?
+      assert_predicate membership, :verified?
       assert_equal "invitee@example.com", membership.verified_email
       assert_equal "invitee@example.com", membership.verified_email_normalized
     end
 
     test "membership_metadata copies through to the membership" do
       membership = invite!(membership_metadata: { member_kind: "employee" }).accept!(@invitee)
+
       assert_equal "employee", membership.metadata["member_kind"]
     end
 
@@ -36,13 +37,14 @@ module Organizations
       membership = invite!.accept!(other, skip_email_validation: true)
 
       assert_equal "invited", membership.joined_via
-      refute membership.verified?
+      refute_predicate membership, :verified?
       assert_nil membership.verified_email
     end
 
     test "skip_email_validation acceptance by the MATCHING email still stamps verified email" do
       membership = invite!.accept!(@invitee, skip_email_validation: true)
-      assert membership.verified?
+
+      assert_predicate membership, :verified?
       assert_equal "invitee@example.com", membership.verified_email
     end
 
@@ -55,8 +57,8 @@ module Organizations
 
       membership = invite!.accept!(@invitee)
 
-      assert membership.persisted?
-      refute membership.verified?
+      assert_predicate membership, :persisted?
+      refute_predicate membership, :verified?
       assert_nil membership.verified_email
     end
 
@@ -86,13 +88,15 @@ module Organizations
                                                  verified_email: "x@corp.com",
                                                  verified_email_normalized: "x@corp.com",
                                                  verified_at: Time.current)
-      assert membership.persisted?
+
+      assert_predicate membership, :persisted?
     end
 
     test "memberships without verified_email are unconstrained (multiple NULLs allowed)" do
       user_b = create_user!(email: "b@example.com")
       @org.add_member!(@invitee)
       @org.add_member!(user_b)
+
       assert_equal 3, @org.memberships.count # owner + 2
     end
   end

--- a/test/models/invitation_provenance_test.rb
+++ b/test/models/invitation_provenance_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organizations
+  # Verified-joining provenance stamped by invitation acceptance (v0.5.0).
+  class InvitationProvenanceTest < Organizations::Test
+    def setup
+      super
+      @org, @owner = create_org_with_owner!(name: "Acme")
+      @invitee = create_user!(email: "invitee@example.com", name: "Invitee")
+    end
+
+    def invite!(email: "invitee@example.com", membership_metadata: {})
+      invitation = @org.send_invite_to!(email, invited_by: @owner)
+      invitation.update!(membership_metadata: membership_metadata) if membership_metadata.any?
+      invitation
+    end
+
+    test "accepting an invitation stamps invited provenance + verified email" do
+      membership = invite!.accept!(@invitee)
+
+      assert_equal "invited", membership.joined_via
+      assert membership.verified?
+      assert_equal "invitee@example.com", membership.verified_email
+      assert_equal "invitee@example.com", membership.verified_email_normalized
+    end
+
+    test "membership_metadata copies through to the membership" do
+      membership = invite!(membership_metadata: { member_kind: "employee" }).accept!(@invitee)
+      assert_equal "employee", membership.metadata["member_kind"]
+    end
+
+    test "skip_email_validation acceptance by a DIFFERENT email does NOT stamp verified email" do
+      other = create_user!(email: "different@example.com")
+      membership = invite!.accept!(other, skip_email_validation: true)
+
+      assert_equal "invited", membership.joined_via
+      refute membership.verified?
+      assert_nil membership.verified_email
+    end
+
+    test "skip_email_validation acceptance by the MATCHING email still stamps verified email" do
+      membership = invite!.accept!(@invitee, skip_email_validation: true)
+      assert membership.verified?
+      assert_equal "invitee@example.com", membership.verified_email
+    end
+
+    test "an address already claimed in the org degrades gracefully (no stamp, membership still created)" do
+      rival = create_user!(email: "rival@example.com")
+      @org.memberships.create!(user: rival, role: "member",
+                               verified_email: "invitee@example.com",
+                               verified_email_normalized: "invitee@example.com",
+                               verified_at: Time.current)
+
+      membership = invite!.accept!(@invitee)
+
+      assert membership.persisted?
+      refute membership.verified?
+      assert_nil membership.verified_email
+    end
+
+    test "verified_email is unique per organization at the DB level" do
+      @org.memberships.create!(user: @invitee, role: "member",
+                               verified_email: "x@corp.com",
+                               verified_email_normalized: "x@corp.com",
+                               verified_at: Time.current)
+
+      rival = create_user!(email: "rival@example.com")
+      assert_raises(ActiveRecord::RecordNotUnique) do
+        @org.memberships.create!(user: rival, role: "member",
+                                 verified_email: "x@corp.com",
+                                 verified_email_normalized: "x@corp.com",
+                                 verified_at: Time.current)
+      end
+    end
+
+    test "the same verified_email CAN exist in two different organizations" do
+      other_org, = create_org_with_owner!(name: "Other")
+      @org.memberships.create!(user: @invitee, role: "member",
+                               verified_email: "x@corp.com",
+                               verified_email_normalized: "x@corp.com",
+                               verified_at: Time.current)
+
+      membership = other_org.memberships.create!(user: @invitee, role: "member",
+                                                 verified_email: "x@corp.com",
+                                                 verified_email_normalized: "x@corp.com",
+                                                 verified_at: Time.current)
+      assert membership.persisted?
+    end
+
+    test "memberships without verified_email are unconstrained (multiple NULLs allowed)" do
+      user_b = create_user!(email: "b@example.com")
+      @org.add_member!(@invitee)
+      @org.add_member!(user_b)
+      assert_equal 3, @org.memberships.count # owner + 2
+    end
+  end
+end

--- a/test/models/invitation_provenance_test.rb
+++ b/test/models/invitation_provenance_test.rb
@@ -92,6 +92,34 @@ module Organizations
       assert_predicate membership, :persisted?
     end
 
+    test "concurrent verified-email claim during acceptance degrades gracefully (race form)" do
+      # Simulate the race where a rival claims the address BETWEEN accept!'s
+      # pre-check and the INSERT: force the stamped attributes despite the
+      # claim and let the unique index fire.
+      rival = create_user!(email: "rival@example.com")
+      invitation = invite!
+      stamped = {
+        verified_email: "invitee@example.com",
+        verified_email_normalized: "invitee@example.com",
+        verified_at: Time.current
+      }
+
+      invitation.stub(:verified_email_attributes_for, stamped) do
+        @org.memberships.create!(user: rival, role: "member",
+                                 verified_email: "invitee@example.com",
+                                 verified_email_normalized: "invitee@example.com",
+                                 verified_at: Time.current)
+
+        membership = invitation.accept!(@invitee)
+
+        assert_predicate membership, :persisted?
+        assert_equal @invitee, membership.user
+        refute_predicate membership, :verified?, "the loser of the race must degrade to an unstamped membership"
+        assert_equal "invited", membership.joined_via
+      end
+      assert_predicate invitation.reload, :accepted?
+    end
+
     test "memberships without verified_email are unconstrained (multiple NULLs allowed)" do
       user_b = create_user!(email: "b@example.com")
       @org.add_member!(@invitee)

--- a/test/models/join_code_test.rb
+++ b/test/models/join_code_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 module Organizations
+  # Comprehensive lifecycle suite — size is the point.
+  # rubocop:disable Metrics/ClassLength
   class JoinCodeTest < Organizations::Test
     def setup
       super
@@ -20,13 +22,15 @@ module Organizations
 
     test "generate_join_code! creates an 8-char code from the ambiguity-free alphabet" do
       code = @org.generate_join_code!
+
       assert_equal 8, code.code.length
-      assert code.code.chars.all? { |c| JoinCode::CODE_ALPHABET.include?(c) }
+      assert(code.code.chars.all? { |c| JoinCode::CODE_ALPHABET.include?(c) })
     end
 
     test "generated codes never contain lookalike characters" do
       20.times do
         code = @org.generate_join_code!
+
         assert_no_match(/[ILO01]/, code.code)
       end
     end
@@ -34,7 +38,8 @@ module Organizations
     test "codes are globally unique — same code cannot exist twice across orgs" do
       other_org, = create_org_with_owner!(name: "Other")
       code = @org.join_codes.create!(code: "AAAABBBB")
-      assert code.persisted?
+
+      assert_predicate code, :persisted?
 
       assert_raises(ActiveRecord::RecordInvalid) { other_org.join_codes.create!(code: "AAAABBBB") }
     end
@@ -42,6 +47,7 @@ module Organizations
     test "custom generator from config is used and normalized" do
       Organizations.configure { |c| c.join_code_generator = -> { "custom-code" } }
       code = @org.generate_join_code!
+
       assert_equal "CUSTOMCODE", code.code
     end
 
@@ -51,6 +57,7 @@ module Organizations
 
     test "display_code groups in fours" do
       code = @org.join_codes.create!(code: "7FHK2MPX")
+
       assert_equal "7FHK-2MPX", code.display_code
     end
 
@@ -66,8 +73,8 @@ module Organizations
       )
 
       assert_equal "cartel cafetería", code.label
-      assert code.requires_verified_domain_email?
-      refute code.auto_approve?
+      assert_predicate code, :requires_verified_domain_email?
+      refute_predicate code, :auto_approve?
       assert_equal 500, code.max_uses
       assert_equal @owner, code.created_by
     end
@@ -78,15 +85,18 @@ module Organizations
 
     test "status transitions: active, revoked, expired, exhausted" do
       code = @org.generate_join_code!(max_uses: 1, expires_at: 1.day.from_now)
-      assert code.active?
+
+      assert_predicate code, :active?
       assert_equal :active, code.status
 
       travel_to(2.days.from_now) { assert_equal :expired, code.status }
 
       code.update!(expires_at: 1.day.from_now, uses_count: 1)
+
       assert_equal :exhausted, code.status
 
       code.revoke!
+
       assert_equal :revoked, code.status
     end
 
@@ -95,6 +105,7 @@ module Organizations
       code.revoke!
       first = code.revoked_at
       code.revoke!
+
       assert_equal first.to_i, code.reload.revoked_at.to_i
     end
 
@@ -118,6 +129,7 @@ module Organizations
 
     test "redeem raises JoinCodeInvalid for expired codes" do
       code = @org.generate_join_code!(expires_at: 1.hour.from_now)
+
       travel_to(2.hours.from_now) do
         assert_raises(JoinCodeInvalid) { JoinCode.redeem(code.code, user: @user) }
       end
@@ -149,7 +161,7 @@ module Organizations
       assert_instance_of Organizations::Membership, membership
       assert_equal "member", membership.role
       assert_equal "code", membership.joined_via
-      refute membership.verified?
+      refute_predicate membership, :verified?
       assert_equal "employee", membership.metadata["member_kind"]
       assert_equal 1, code.reload.uses_count
     end
@@ -159,14 +171,16 @@ module Organizations
       JoinCode.redeem(code.code, user: @user)
 
       request = @org.join_requests.find_by(user_id: @user.id)
-      assert request.approved?
+
+      assert_predicate request, :approved?
       assert_equal code, request.join_code
       assert_nil request.decided_by
     end
 
     test "input is normalized at redemption (typed with hyphens/lowercase)" do
-      code = @org.join_codes.create!(code: "7FHK2MPX")
+      @org.join_codes.create!(code: "7FHK2MPX")
       membership = JoinCode.redeem("7fhk-2mpx", user: @user)
+
       assert_instance_of Organizations::Membership, membership
     end
 
@@ -195,7 +209,7 @@ module Organizations
       outcome = JoinCode.redeem(code.code, user: @user)
 
       assert_instance_of Organizations::JoinRequest, outcome
-      assert outcome.pending?
+      assert_predicate outcome, :pending?
       assert_equal "code", outcome.joined_via
       refute @org.has_member?(@user)
       assert_equal 1, code.reload.uses_count
@@ -207,7 +221,7 @@ module Organizations
       outcome = JoinCode.redeem(code.code, user: @user)
 
       assert_instance_of Organizations::JoinRequest, outcome
-      assert outcome.pending?
+      assert_predicate outcome, :pending?
       refute @org.has_member?(@user)
     end
 
@@ -260,4 +274,5 @@ module Organizations
       assert_equal 1, code_b.reload.uses_count
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/test/models/join_code_test.rb
+++ b/test/models/join_code_test.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organizations
+  class JoinCodeTest < Organizations::Test
+    def setup
+      super
+      @org, @owner = create_org_with_owner!(name: "Inizio")
+      @user = create_user!(email: "personal@gmail.com", name: "Joiner")
+    end
+
+    test "table_name is organizations_join_codes" do
+      assert_equal "organizations_join_codes", Organizations::JoinCode.table_name
+    end
+
+    # =========================================================================
+    # Generation & normalization
+    # =========================================================================
+
+    test "generate_join_code! creates an 8-char code from the ambiguity-free alphabet" do
+      code = @org.generate_join_code!
+      assert_equal 8, code.code.length
+      assert code.code.chars.all? { |c| JoinCode::CODE_ALPHABET.include?(c) }
+    end
+
+    test "generated codes never contain lookalike characters" do
+      20.times do
+        code = @org.generate_join_code!
+        assert_no_match(/[ILO01]/, code.code)
+      end
+    end
+
+    test "codes are globally unique — same code cannot exist twice across orgs" do
+      other_org, = create_org_with_owner!(name: "Other")
+      code = @org.join_codes.create!(code: "AAAABBBB")
+      assert code.persisted?
+
+      assert_raises(ActiveRecord::RecordInvalid) { other_org.join_codes.create!(code: "AAAABBBB") }
+    end
+
+    test "custom generator from config is used and normalized" do
+      Organizations.configure { |c| c.join_code_generator = -> { "custom-code" } }
+      code = @org.generate_join_code!
+      assert_equal "CUSTOMCODE", code.code
+    end
+
+    test "input normalization strips case, hyphens, and spaces" do
+      assert_equal "7FHK2MPX", JoinCode.normalize("  7fhk-2mpx ")
+    end
+
+    test "display_code groups in fours" do
+      code = @org.join_codes.create!(code: "7FHK2MPX")
+      assert_equal "7FHK-2MPX", code.display_code
+    end
+
+    test "generate_join_code! carries label, caps, expiry, metadata and creator" do
+      code = @org.generate_join_code!(
+        label: "cartel cafetería",
+        requires_verified_domain_email: true,
+        auto_approve: false,
+        expires_at: 3.months.from_now,
+        max_uses: 500,
+        created_by: @owner,
+        membership_metadata: { member_kind: "employee" }
+      )
+
+      assert_equal "cartel cafetería", code.label
+      assert code.requires_verified_domain_email?
+      refute code.auto_approve?
+      assert_equal 500, code.max_uses
+      assert_equal @owner, code.created_by
+    end
+
+    # =========================================================================
+    # Status
+    # =========================================================================
+
+    test "status transitions: active, revoked, expired, exhausted" do
+      code = @org.generate_join_code!(max_uses: 1, expires_at: 1.day.from_now)
+      assert code.active?
+      assert_equal :active, code.status
+
+      travel_to(2.days.from_now) { assert_equal :expired, code.status }
+
+      code.update!(expires_at: 1.day.from_now, uses_count: 1)
+      assert_equal :exhausted, code.status
+
+      code.revoke!
+      assert_equal :revoked, code.status
+    end
+
+    test "revoke! is idempotent" do
+      code = @org.generate_join_code!
+      code.revoke!
+      first = code.revoked_at
+      code.revoke!
+      assert_equal first.to_i, code.reload.revoked_at.to_i
+    end
+
+    # =========================================================================
+    # Redemption — failure modes
+    # =========================================================================
+
+    test "redeem raises JoinCodeInvalid for unknown codes" do
+      assert_raises(JoinCodeInvalid) { JoinCode.redeem("NOPE9999", user: @user) }
+    end
+
+    test "redeem raises JoinCodeInvalid for blank input" do
+      assert_raises(JoinCodeInvalid) { JoinCode.redeem("  - -", user: @user) }
+    end
+
+    test "redeem raises JoinCodeInvalid for revoked codes" do
+      code = @org.generate_join_code!
+      code.revoke!
+      assert_raises(JoinCodeInvalid) { JoinCode.redeem(code.code, user: @user) }
+    end
+
+    test "redeem raises JoinCodeInvalid for expired codes" do
+      code = @org.generate_join_code!(expires_at: 1.hour.from_now)
+      travel_to(2.hours.from_now) do
+        assert_raises(JoinCodeInvalid) { JoinCode.redeem(code.code, user: @user) }
+      end
+    end
+
+    test "redeem raises JoinCodeExhausted at max_uses (E10 deterministic form)" do
+      code = @org.generate_join_code!(max_uses: 1)
+      JoinCode.redeem(code.code, user: @user)
+
+      second_user = create_user!(email: "second@gmail.com")
+      assert_raises(JoinCodeExhausted) { JoinCode.redeem(code.code, user: second_user) }
+      assert_equal 1, code.reload.uses_count
+    end
+
+    test "redeem requires a user" do
+      code = @org.generate_join_code!
+      assert_raises(ArgumentError) { code.redeem!(user: nil) }
+    end
+
+    # =========================================================================
+    # Redemption — P2 (basic, instant membership)
+    # =========================================================================
+
+    test "basic auto-approve code grants instant membership with provenance" do
+      code = @org.generate_join_code!(membership_metadata: { member_kind: "employee" })
+
+      membership = JoinCode.redeem(code.code, user: @user)
+
+      assert_instance_of Organizations::Membership, membership
+      assert_equal "member", membership.role
+      assert_equal "code", membership.joined_via
+      refute membership.verified?
+      assert_equal "employee", membership.metadata["member_kind"]
+      assert_equal 1, code.reload.uses_count
+    end
+
+    test "instant join records an approved join request (audit trail)" do
+      code = @org.generate_join_code!
+      JoinCode.redeem(code.code, user: @user)
+
+      request = @org.join_requests.find_by(user_id: @user.id)
+      assert request.approved?
+      assert_equal code, request.join_code
+      assert_nil request.decided_by
+    end
+
+    test "input is normalized at redemption (typed with hyphens/lowercase)" do
+      code = @org.join_codes.create!(code: "7FHK2MPX")
+      membership = JoinCode.redeem("7fhk-2mpx", user: @user)
+      assert_instance_of Organizations::Membership, membership
+    end
+
+    test "member_joined and join_request_approved callbacks fire on instant join" do
+      events = []
+      Organizations.configure do |config|
+        config.on_member_joined { |ctx| events << [:member_joined, ctx.user.id] }
+        config.on_join_request_approved { |ctx| events << [:approved, ctx.decided_by] }
+      end
+
+      code = @org.generate_join_code!
+      JoinCode.redeem(code.code, user: @user)
+
+      assert_includes events, [:member_joined, @user.id]
+      assert_includes events, [:approved, nil]
+    end
+
+    # =========================================================================
+    # Redemption — pending outcomes (P3 / manual approval)
+    # =========================================================================
+
+    test "reinforced code (requires_verified_domain_email) parks a pending request" do
+      @org.add_domain!("inizio.com")
+      code = @org.generate_join_code!(requires_verified_domain_email: true)
+
+      outcome = JoinCode.redeem(code.code, user: @user)
+
+      assert_instance_of Organizations::JoinRequest, outcome
+      assert outcome.pending?
+      assert_equal "code", outcome.joined_via
+      refute @org.has_member?(@user)
+      assert_equal 1, code.reload.uses_count
+    end
+
+    test "auto_approve: false parks a pending request for manual review" do
+      code = @org.generate_join_code!(auto_approve: false)
+
+      outcome = JoinCode.redeem(code.code, user: @user)
+
+      assert_instance_of Organizations::JoinRequest, outcome
+      assert outcome.pending?
+      refute @org.has_member?(@user)
+    end
+
+    # =========================================================================
+    # Redemption — idempotency
+    # =========================================================================
+
+    test "redeeming as an existing member returns the membership WITHOUT consuming a use" do
+      @org.add_member!(@user)
+      code = @org.generate_join_code!(max_uses: 5)
+
+      membership = JoinCode.redeem(code.code, user: @user)
+
+      assert_instance_of Organizations::Membership, membership
+      assert_equal 0, code.reload.uses_count
+    end
+
+    test "re-redeeming the same pending code does not double-consume uses" do
+      code = @org.generate_join_code!(auto_approve: false, max_uses: 5)
+
+      first = JoinCode.redeem(code.code, user: @user)
+      second = JoinCode.redeem(code.code, user: @user)
+
+      assert_equal first.id, second.id
+      assert_equal 1, code.reload.uses_count
+    end
+
+    test "redeeming a code upgrades an existing plain join request instead of colliding (E9 family)" do
+      request = @user.request_to_join!(@org, message: "hola")
+      code = @org.generate_join_code!(auto_approve: false)
+
+      outcome = JoinCode.redeem(code.code, user: @user)
+
+      assert_equal request.id, outcome.id
+      assert_equal code, outcome.join_code
+      assert_equal "code", outcome.joined_via
+      assert_equal 1, code.reload.uses_count
+    end
+
+    test "redeeming a second different code moves the pending request to it and consumes a use" do
+      code_a = @org.generate_join_code!(auto_approve: false)
+      code_b = @org.generate_join_code!(auto_approve: false)
+
+      first = JoinCode.redeem(code_a.code, user: @user)
+      second = JoinCode.redeem(code_b.code, user: @user)
+
+      assert_equal first.id, second.id
+      assert_equal code_b, second.reload.join_code
+      assert_equal 1, code_a.reload.uses_count
+      assert_equal 1, code_b.reload.uses_count
+    end
+  end
+end

--- a/test/models/join_code_test.rb
+++ b/test/models/join_code_test.rb
@@ -261,6 +261,30 @@ module Organizations
       assert_equal 1, code.reload.uses_count
     end
 
+    test "redeeming a basic code mid-challenge approves immediately; the unfinished challenge dies with the approval" do
+      # Reviewer-requested transition: user starts a domain-email challenge,
+      # then redeems a basic auto-approve code BEFORE completing it. The code
+      # wins: instant membership with code provenance, NOT email-verified
+      # (the inbox was never proven), domain metadata still merged (the
+      # matched_domain_id survives on the request).
+      @org.add_domain!("inizio.com", membership_metadata: { member_kind: "employee" })
+      request = @user.request_to_join!(@org)
+      SecureRandom.stub(:random_number, 424_242) do
+        request.start_email_verification!(email: "j@inizio.com")
+      end
+
+      code = @org.generate_join_code!(membership_metadata: { from: "code" })
+      membership = JoinCode.redeem(code.code, user: @user)
+
+      assert_instance_of Organizations::Membership, membership
+      assert_equal "code", membership.joined_via
+      refute_predicate membership, :verified?, "an unfinished challenge must not stamp verified_email"
+      assert_nil membership.verified_email
+      assert_equal "employee", membership.metadata["member_kind"]
+      assert_equal "code", membership.metadata["from"]
+      assert_predicate request.reload, :approved?
+    end
+
     test "redeeming a second different code moves the pending request to it and consumes a use" do
       code_a = @org.generate_join_code!(auto_approve: false)
       code_b = @org.generate_join_code!(auto_approve: false)

--- a/test/models/join_request_test.rb
+++ b/test/models/join_request_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 module Organizations
+  # Comprehensive lifecycle suite — size is the point.
+  # rubocop:disable Metrics/ClassLength
   class JoinRequestTest < Organizations::Test
     include ActiveJob::TestHelper
 
@@ -34,7 +36,7 @@ module Organizations
     test "request_to_join! creates a pending request with expiry from config" do
       request = @user.request_to_join!(@org, message: "Soy socio nº 442")
 
-      assert request.pending?
+      assert_predicate request, :pending?
       assert_equal "Soy socio nº 442", request.message
       assert_in_delta 30.days.from_now.to_i, request.expires_at.to_i, 5
     end
@@ -42,6 +44,7 @@ module Organizations
     test "request_to_join! is idempotent — returns the existing open request" do
       first = @user.request_to_join!(@org)
       second = @user.request_to_join!(@org)
+
       assert_equal first.id, second.id
       assert_equal 1, @org.join_requests.count
     end
@@ -68,8 +71,9 @@ module Organizations
     test "pending uniqueness is validated (one open request per org per user)" do
       @user.request_to_join!(@org)
       duplicate = @org.join_requests.new(user: @user)
-      refute duplicate.valid?
-      assert duplicate.errors[:user_id].any?
+
+      refute_predicate duplicate, :valid?
+      assert_predicate duplicate.errors[:user_id], :any?
     end
 
     test "a decided request does not block a new one" do
@@ -77,6 +81,7 @@ module Organizations
       request.withdraw!
 
       fresh = @user.request_to_join!(@org)
+
       refute_equal request.id, fresh.id
     end
 
@@ -88,8 +93,8 @@ module Organizations
       request = @user.request_to_join!(@org)
 
       travel_to(31.days.from_now) do
-        assert request.expired?
-        refute request.pending?
+        assert_predicate request, :expired?
+        refute_predicate request, :pending?
         assert_equal :expired, request.effective_status
         assert_empty @org.join_requests.pending
         assert_includes @org.join_requests.expired, request
@@ -98,6 +103,7 @@ module Organizations
 
     test "approve! refuses expired requests" do
       request = @user.request_to_join!(@org)
+
       travel_to(31.days.from_now) do
         assert_raises(JoinRequestExpired) { request.approve!(decided_by: @owner) }
       end
@@ -107,16 +113,18 @@ module Organizations
       request = @user.request_to_join!(@org)
       travel_to(31.days.from_now) do
         request.reject!(rejected_by: @owner)
-        assert request.rejected?
+
+        assert_predicate request, :rejected?
       end
     end
 
     test "nil join_request_expiry means requests never expire" do
       Organizations.configure { |c| c.join_request_expiry = nil }
       request = @user.request_to_join!(@org)
+
       assert_nil request.expires_at
 
-      travel_to(10.years.from_now) { assert request.pending? }
+      travel_to(10.years.from_now) { assert_predicate request, :pending? }
     end
 
     # =========================================================================
@@ -129,8 +137,8 @@ module Organizations
 
       assert_equal "member", membership.role
       assert_equal "manual", membership.joined_via
-      refute membership.verified?
-      assert request.reload.approved?
+      refute_predicate membership, :verified?
+      assert_predicate request.reload, :approved?
       assert_equal @owner, request.decided_by
       assert_not_nil request.decided_at
     end
@@ -139,6 +147,7 @@ module Organizations
       request = @user.request_to_join!(@org)
       first = request.approve!(decided_by: @owner)
       second = request.approve!(decided_by: @owner)
+
       assert_equal first.id, second.id
     end
 
@@ -156,7 +165,7 @@ module Organizations
 
       assert_equal @org.memberships.find_by(user_id: @user.id).id, membership.id
       assert_equal joined_before, joined_events, "member_joined must not fire for a reused membership"
-      assert request.reload.approved?
+      assert_predicate request.reload, :approved?
     end
 
     test "approve! fires member_joined and join_request_approved with decided_by" do
@@ -182,7 +191,7 @@ module Organizations
       request = @user.request_to_join!(@org)
       request.reject!(rejected_by: @owner, reason: "no consta como socio")
 
-      assert request.rejected?
+      assert_predicate request, :rejected?
       assert_equal @owner, request.decided_by
       assert_equal "no consta como socio", request.metadata["rejection_reason"]
       assert_equal :join_request_rejected, rejected.event
@@ -199,7 +208,7 @@ module Organizations
       request = @user.request_to_join!(@org)
       request.withdraw!
 
-      assert request.withdrawn?
+      assert_predicate request, :withdrawn?
       assert_raises(JoinRequestAlreadyDecided) { request.withdraw! }
       assert_raises(JoinRequestAlreadyDecided) { request.reject!(rejected_by: @owner) }
     end
@@ -267,7 +276,7 @@ module Organizations
                    request.verification_code_digest
 
       # No column anywhere carries the plaintext
-      refute request.attributes.values.map(&:to_s).include?(FIXED_CODE)
+      refute_includes request.attributes.values.map(&:to_s), FIXED_CODE
     end
 
     test "an unclaimed allowlist entry is eligible (P6) and sets allowlist provenance" do
@@ -359,12 +368,12 @@ module Organizations
       membership = request.verify_email_code!(FIXED_CODE)
 
       assert_instance_of Organizations::Membership, membership
-      assert membership.verified?
+      assert_predicate membership, :verified?
       assert_equal "j.doe@inizio.com", membership.verified_email
       assert_equal "j.doe@inizio.com", membership.verified_email_normalized
       assert_equal "domain_email", membership.joined_via
       assert_equal "employee", membership.metadata["member_kind"]
-      assert request.reload.approved?
+      assert_predicate request.reload, :approved?
       assert_nil request.decided_by
     end
 
@@ -441,7 +450,7 @@ module Organizations
 
       assert_instance_of Organizations::Membership, membership
       assert_equal "code", membership.joined_via
-      assert membership.verified?
+      assert_predicate membership, :verified?
       # Precedence: domain < code (later wins)
       assert_equal "code", membership.metadata["from"]
       assert_equal "employee", membership.metadata["member_kind"]
@@ -456,12 +465,13 @@ module Organizations
       outcome = request.verify_email_code!(FIXED_CODE)
 
       assert_equal request, outcome
-      assert request.pending?
-      assert request.email_verified?
+      assert_predicate request, :pending?
+      assert_predicate request, :email_verified?
       refute @org.has_member?(@user)
 
       membership = @org.approve_join_request!(request, approved_by: @owner)
-      assert membership.verified?
+
+      assert_predicate membership, :verified?
       assert_equal "j@inizio.com", membership.verified_email
     end
 
@@ -473,7 +483,8 @@ module Organizations
       membership = request.verify_email_code!(FIXED_CODE)
 
       entry = @org.allowlist_entries.first
-      assert entry.claimed?
+
+      assert_predicate entry, :claimed?
       assert_equal @user, entry.claimed_by
       assert_equal "allowlist", membership.joined_via
       assert_equal "member", membership.metadata["member_kind"]
@@ -507,11 +518,11 @@ module Organizations
 
       assert_equal "domain_email", membership.joined_via
       assert_equal "prof@urjc.es", membership.verified_email
-      assert membership.verified?
+      assert_predicate membership, :verified?
       assert_equal "employee", membership.metadata["member_kind"]
 
       # Uniform funnel: the join left an approved request behind
-      assert @org.join_requests.find_by(user_id: prof.id).approved?
+      assert_predicate @org.join_requests.find_by(user_id: prof.id), :approved?
     end
 
     test "unconfirmed account email is refused" do
@@ -551,20 +562,25 @@ module Organizations
     # =========================================================================
 
     test "accepts_join_requests? reflects available mechanisms" do
-      refute @org.accepts_join_requests?
+      refute_predicate @org, :accepts_join_requests?
 
       domain = @org.add_domain!("inizio.com")
-      assert @org.accepts_join_requests?
+
+      assert_predicate @org, :accepts_join_requests?
 
       domain.destroy!
       code = @org.generate_join_code!
-      assert @org.accepts_join_requests?
+
+      assert_predicate @org, :accepts_join_requests?
 
       code.revoke!
-      refute @org.accepts_join_requests?
+
+      refute_predicate @org, :accepts_join_requests?
 
       @org.import_allowlist!(["ana@gmail.com"])
-      assert @org.accepts_join_requests?
+
+      assert_predicate @org, :accepts_join_requests?
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/test/models/join_request_test.rb
+++ b/test/models/join_request_test.rb
@@ -1,0 +1,570 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organizations
+  class JoinRequestTest < Organizations::Test
+    include ActiveJob::TestHelper
+
+    def setup
+      super
+      @org, @owner = create_org_with_owner!(name: "Inizio")
+      @user = create_user!(email: "personal@gmail.com", name: "Joiner")
+    end
+
+    # Deterministic challenge: stub the code RNG so the emailed code is known.
+    FIXED_CODE_NUMBER = 424_242
+    FIXED_CODE = "424242"
+
+    def start_challenge!(request, email:)
+      SecureRandom.stub(:random_number, FIXED_CODE_NUMBER) do
+        request.start_email_verification!(email: email)
+      end
+      request
+    end
+
+    test "table_name is organizations_join_requests" do
+      assert_equal "organizations_join_requests", Organizations::JoinRequest.table_name
+    end
+
+    # =========================================================================
+    # request_to_join! (P8)
+    # =========================================================================
+
+    test "request_to_join! creates a pending request with expiry from config" do
+      request = @user.request_to_join!(@org, message: "Soy socio nº 442")
+
+      assert request.pending?
+      assert_equal "Soy socio nº 442", request.message
+      assert_in_delta 30.days.from_now.to_i, request.expires_at.to_i, 5
+    end
+
+    test "request_to_join! is idempotent — returns the existing open request" do
+      first = @user.request_to_join!(@org)
+      second = @user.request_to_join!(@org)
+      assert_equal first.id, second.id
+      assert_equal 1, @org.join_requests.count
+    end
+
+    test "request_to_join! raises for existing members" do
+      @org.add_member!(@user)
+      assert_raises(JoinRequestAlreadyDecided) { @user.request_to_join!(@org) }
+    end
+
+    test "request_to_join! fires the join_request_created callback" do
+      created = nil
+      Organizations.configure do |config|
+        config.on_join_request_created { |ctx| created = ctx }
+      end
+
+      request = @user.request_to_join!(@org)
+
+      assert_equal :join_request_created, created.event
+      assert_equal @org, created.organization
+      assert_equal @user, created.user
+      assert_equal request, created.join_request
+    end
+
+    test "pending uniqueness is validated (one open request per org per user)" do
+      @user.request_to_join!(@org)
+      duplicate = @org.join_requests.new(user: @user)
+      refute duplicate.valid?
+      assert duplicate.errors[:user_id].any?
+    end
+
+    test "a decided request does not block a new one" do
+      request = @user.request_to_join!(@org)
+      request.withdraw!
+
+      fresh = @user.request_to_join!(@org)
+      refute_equal request.id, fresh.id
+    end
+
+    # =========================================================================
+    # Expiry
+    # =========================================================================
+
+    test "requests expire by derived status, mirroring invitations" do
+      request = @user.request_to_join!(@org)
+
+      travel_to(31.days.from_now) do
+        assert request.expired?
+        refute request.pending?
+        assert_equal :expired, request.effective_status
+        assert_empty @org.join_requests.pending
+        assert_includes @org.join_requests.expired, request
+      end
+    end
+
+    test "approve! refuses expired requests" do
+      request = @user.request_to_join!(@org)
+      travel_to(31.days.from_now) do
+        assert_raises(JoinRequestExpired) { request.approve!(decided_by: @owner) }
+      end
+    end
+
+    test "reject! still works on expired requests (cleanup path)" do
+      request = @user.request_to_join!(@org)
+      travel_to(31.days.from_now) do
+        request.reject!(rejected_by: @owner)
+        assert request.rejected?
+      end
+    end
+
+    test "nil join_request_expiry means requests never expire" do
+      Organizations.configure { |c| c.join_request_expiry = nil }
+      request = @user.request_to_join!(@org)
+      assert_nil request.expires_at
+
+      travel_to(10.years.from_now) { assert request.pending? }
+    end
+
+    # =========================================================================
+    # Decisions: approve / reject / withdraw
+    # =========================================================================
+
+    test "approve! creates a member-role membership with manual provenance" do
+      request = @user.request_to_join!(@org)
+      membership = @org.approve_join_request!(request, approved_by: @owner)
+
+      assert_equal "member", membership.role
+      assert_equal "manual", membership.joined_via
+      refute membership.verified?
+      assert request.reload.approved?
+      assert_equal @owner, request.decided_by
+      assert_not_nil request.decided_at
+    end
+
+    test "approve! is idempotent — double approval returns the same membership" do
+      request = @user.request_to_join!(@org)
+      first = request.approve!(decided_by: @owner)
+      second = request.approve!(decided_by: @owner)
+      assert_equal first.id, second.id
+    end
+
+    test "approve! reuses an existing membership without firing member_joined twice" do
+      joined_events = 0
+      Organizations.configure do |config|
+        config.on_member_joined { |_ctx| joined_events += 1 }
+      end
+
+      request = @user.request_to_join!(@org)
+      @org.add_member!(@user) # membership arrives via another path first
+      joined_before = joined_events
+
+      membership = request.approve!(decided_by: @owner)
+
+      assert_equal @org.memberships.find_by(user_id: @user.id).id, membership.id
+      assert_equal joined_before, joined_events, "member_joined must not fire for a reused membership"
+      assert request.reload.approved?
+    end
+
+    test "approve! fires member_joined and join_request_approved with decided_by" do
+      events = []
+      Organizations.configure do |config|
+        config.on_member_joined { |ctx| events << [:joined, ctx.membership.user_id] }
+        config.on_join_request_approved { |ctx| events << [:approved, ctx.decided_by&.id, ctx.membership.present?] }
+      end
+
+      request = @user.request_to_join!(@org)
+      request.approve!(decided_by: @owner)
+
+      assert_includes events, [:joined, @user.id]
+      assert_includes events, [:approved, @owner.id, true]
+    end
+
+    test "reject! stamps decision, stores the reason in metadata, fires callback" do
+      rejected = nil
+      Organizations.configure do |config|
+        config.on_join_request_rejected { |ctx| rejected = ctx }
+      end
+
+      request = @user.request_to_join!(@org)
+      request.reject!(rejected_by: @owner, reason: "no consta como socio")
+
+      assert request.rejected?
+      assert_equal @owner, request.decided_by
+      assert_equal "no consta como socio", request.metadata["rejection_reason"]
+      assert_equal :join_request_rejected, rejected.event
+      assert_equal @owner, rejected.decided_by
+    end
+
+    test "approve! refuses already-rejected requests" do
+      request = @user.request_to_join!(@org)
+      request.reject!(rejected_by: @owner)
+      assert_raises(JoinRequestAlreadyDecided) { request.approve!(decided_by: @owner) }
+    end
+
+    test "withdraw! closes the request; further decisions refuse" do
+      request = @user.request_to_join!(@org)
+      request.withdraw!
+
+      assert request.withdrawn?
+      assert_raises(JoinRequestAlreadyDecided) { request.withdraw! }
+      assert_raises(JoinRequestAlreadyDecided) { request.reject!(rejected_by: @owner) }
+    end
+
+    test "organization-level helpers guard against foreign requests" do
+      other_org, = create_org_with_owner!(name: "Other")
+      request = @user.request_to_join!(other_org)
+
+      assert_raises(ArgumentError) { @org.approve_join_request!(request, approved_by: @owner) }
+      assert_raises(ArgumentError) { @org.reject_join_request!(request, rejected_by: @owner) }
+    end
+
+    # =========================================================================
+    # Email verification — eligibility & sending (P4/P6)
+    # =========================================================================
+
+    test "start_email_verification! rejects invalid email shapes" do
+      request = @user.request_to_join!(@org)
+      assert_raises(VerificationEmailNotEligible) do
+        request.start_email_verification!(email: "not-an-email")
+      end
+    end
+
+    test "start_email_verification! rejects emails not eligible for the org" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+
+      assert_raises(VerificationEmailNotEligible) do
+        request.start_email_verification!(email: "j@otracosa.com")
+      end
+    end
+
+    test "start_email_verification! rejects lookalike domains (E4)" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+
+      assert_raises(VerificationEmailNotEligible) do
+        request.start_email_verification!(email: "j@inizio.com.evil.com")
+      end
+    end
+
+    test "a matching org domain starts the challenge and enqueues the code email" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+
+      assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+        start_challenge!(request, email: "j.doe@inizio.com")
+      end
+
+      assert_equal "j.doe@inizio.com", request.verification_email
+      assert_equal "j.doe@inizio.com", request.verification_email_normalized
+      assert_equal "domain_email", request.joined_via
+      assert_not_nil request.verification_sent_at
+      assert_equal 1, request.verification_sends_count
+    end
+
+    test "the code is stored as a digest only — plaintext never persisted" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+
+      assert_not_nil request.verification_code_digest
+      refute_equal FIXED_CODE, request.verification_code_digest
+      assert_equal JoinRequest.digest_verification_code(FIXED_CODE, request.id),
+                   request.verification_code_digest
+
+      # No column anywhere carries the plaintext
+      refute request.attributes.values.map(&:to_s).include?(FIXED_CODE)
+    end
+
+    test "an unclaimed allowlist entry is eligible (P6) and sets allowlist provenance" do
+      @org.import_allowlist!(["ana@gmail.com"])
+      request = @user.request_to_join!(@org)
+
+      start_challenge!(request, email: "ana@gmail.com")
+
+      assert_equal "allowlist", request.joined_via
+    end
+
+    test "a claimed allowlist entry is NOT eligible" do
+      entry = @org.allowlist_entries.create!(email: "ana@gmail.com")
+      entry.claim!(create_user!(email: "prior@gmail.com"))
+
+      request = @user.request_to_join!(@org)
+      assert_raises(VerificationEmailNotEligible) do
+        request.start_email_verification!(email: "ana@gmail.com")
+      end
+    end
+
+    test "an email already claimed by a membership is rejected up front (E2)" do
+      @org.add_domain!("inizio.com")
+      prior = create_user!(email: "prior@gmail.com")
+      prior_request = prior.request_to_join!(@org)
+      start_challenge!(prior_request, email: "j.doe@inizio.com")
+      prior_request.verify_email_code!(FIXED_CODE)
+
+      request = @user.request_to_join!(@org)
+      error = assert_raises(VerificationEmailAlreadyClaimed) do
+        request.start_email_verification!(email: "J.Doe+bis@inizio.com") # plus-tag collapses (E3)
+      end
+      # The error must not reveal WHO holds the address
+      refute_match(/prior/, error.message)
+    end
+
+    # =========================================================================
+    # Email verification — throttles
+    # =========================================================================
+
+    test "resend inside the interval is throttled" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+
+      assert_raises(VerificationThrottled) do
+        request.start_email_verification!(email: "j@inizio.com")
+      end
+    end
+
+    test "resend after the interval succeeds and resets attempts" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+      request.update!(verification_attempts: 3)
+
+      travel_to(61.seconds.from_now) do
+        start_challenge!(request, email: "j@inizio.com")
+      end
+
+      assert_equal 0, request.verification_attempts
+      assert_equal 2, request.verification_sends_count
+    end
+
+    test "the per-request send cap is enforced" do
+      Organizations.configure { |c| c.verification_max_sends = 2 }
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+
+      start_challenge!(request, email: "j@inizio.com")
+      travel_to(2.minutes.from_now) { start_challenge!(request, email: "j@inizio.com") }
+
+      travel_to(4.minutes.from_now) do
+        assert_raises(VerificationThrottled) do
+          request.start_email_verification!(email: "j@inizio.com")
+        end
+      end
+    end
+
+    # =========================================================================
+    # Email verification — verify_email_code!
+    # =========================================================================
+
+    test "the correct code verifies and auto-approves a domain join (P4)" do
+      @org.add_domain!("inizio.com", membership_metadata: { member_kind: "employee" })
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j.doe@inizio.com")
+
+      membership = request.verify_email_code!(FIXED_CODE)
+
+      assert_instance_of Organizations::Membership, membership
+      assert membership.verified?
+      assert_equal "j.doe@inizio.com", membership.verified_email
+      assert_equal "j.doe@inizio.com", membership.verified_email_normalized
+      assert_equal "domain_email", membership.joined_via
+      assert_equal "employee", membership.metadata["member_kind"]
+      assert request.reload.approved?
+      assert_nil request.decided_by
+    end
+
+    test "verification input tolerates surrounding whitespace" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+
+      assert_instance_of Organizations::Membership, request.verify_email_code!(" #{FIXED_CODE} ")
+    end
+
+    test "a wrong code raises AND persists the attempt (no rollback loophole)" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+
+      assert_raises(VerificationCodeInvalid) { request.verify_email_code!("000000") }
+      assert_equal 1, request.reload.verification_attempts
+    end
+
+    test "attempts exhaust after verification_max_attempts wrong tries" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+
+      5.times do
+        assert_raises(VerificationCodeInvalid) { request.verify_email_code!("000000") }
+      rescue VerificationAttemptsExceeded
+        # Reached the cap inside the loop on the 5th, fine
+      end
+
+      assert_raises(VerificationAttemptsExceeded) { request.verify_email_code!(FIXED_CODE) }
+    end
+
+    test "codes expire after verification_code_ttl" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+
+      travel_to(16.minutes.from_now) do
+        assert_raises(VerificationCodeExpired) { request.verify_email_code!(FIXED_CODE) }
+      end
+    end
+
+    test "a verified code is burned — it cannot be replayed" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+      request.verify_email_code!(FIXED_CODE)
+
+      # Request is approved now; a new user can't replay anything, and even
+      # re-verifying this request refuses (decided + no active code).
+      assert_raises(JoinRequestAlreadyDecided) { request.verify_email_code!(FIXED_CODE) }
+      assert_nil request.reload.verification_code_digest
+    end
+
+    test "verify without any active challenge raises VerificationCodeInvalid" do
+      request = @user.request_to_join!(@org)
+      assert_raises(VerificationCodeInvalid) { request.verify_email_code!(FIXED_CODE) }
+    end
+
+    # =========================================================================
+    # Reinforced code joins (P3) & metadata precedence
+    # =========================================================================
+
+    test "reinforced code join: code + domain challenge => membership with code provenance" do
+      @org.add_domain!("inizio.com", membership_metadata: { member_kind: "employee", from: "domain" })
+      code = @org.generate_join_code!(requires_verified_domain_email: true,
+                                      membership_metadata: { from: "code" })
+
+      request = JoinCode.redeem(code.code, user: @user)
+      start_challenge!(request, email: "j@inizio.com")
+      membership = request.verify_email_code!(FIXED_CODE)
+
+      assert_instance_of Organizations::Membership, membership
+      assert_equal "code", membership.joined_via
+      assert membership.verified?
+      # Precedence: domain < code (later wins)
+      assert_equal "code", membership.metadata["from"]
+      assert_equal "employee", membership.metadata["member_kind"]
+    end
+
+    test "reinforced code with auto_approve: false stays pending after verification" do
+      @org.add_domain!("inizio.com")
+      code = @org.generate_join_code!(requires_verified_domain_email: true, auto_approve: false)
+
+      request = JoinCode.redeem(code.code, user: @user)
+      start_challenge!(request, email: "j@inizio.com")
+      outcome = request.verify_email_code!(FIXED_CODE)
+
+      assert_equal request, outcome
+      assert request.pending?
+      assert request.email_verified?
+      refute @org.has_member?(@user)
+
+      membership = @org.approve_join_request!(request, approved_by: @owner)
+      assert membership.verified?
+      assert_equal "j@inizio.com", membership.verified_email
+    end
+
+    test "allowlist join claims the entry on approval (P6)" do
+      @org.import_allowlist!(["ana@gmail.com"], membership_metadata: { member_kind: "member" })
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "ana@gmail.com")
+
+      membership = request.verify_email_code!(FIXED_CODE)
+
+      entry = @org.allowlist_entries.first
+      assert entry.claimed?
+      assert_equal @user, entry.claimed_by
+      assert_equal "allowlist", membership.joined_via
+      assert_equal "member", membership.metadata["member_kind"]
+    end
+
+    test "verified_email uniqueness race is backstopped at membership creation (E2 race form)" do
+      @org.add_domain!("inizio.com")
+      request = @user.request_to_join!(@org)
+      start_challenge!(request, email: "j@inizio.com")
+
+      # Simulate a concurrent claim landing between challenge start and verify:
+      rival = create_user!(email: "rival@gmail.com")
+      @org.memberships.create!(user: rival, role: "member",
+                               verified_email: "j@inizio.com",
+                               verified_email_normalized: "j@inizio.com",
+                               verified_at: Time.current)
+
+      assert_raises(VerificationEmailAlreadyClaimed) { request.verify_email_code!(FIXED_CODE) }
+      refute @org.has_member?(@user)
+    end
+
+    # =========================================================================
+    # join_with_account_email! (P5)
+    # =========================================================================
+
+    test "confirmed account email under an org domain joins in one call" do
+      @org.add_domain!("urjc.es", membership_metadata: { member_kind: "employee" })
+      prof = User.create!(email: "prof@urjc.es", name: "Prof", confirmed_at: Time.current)
+
+      membership = @org.join_with_account_email!(prof)
+
+      assert_equal "domain_email", membership.joined_via
+      assert_equal "prof@urjc.es", membership.verified_email
+      assert membership.verified?
+      assert_equal "employee", membership.metadata["member_kind"]
+
+      # Uniform funnel: the join left an approved request behind
+      assert @org.join_requests.find_by(user_id: prof.id).approved?
+    end
+
+    test "unconfirmed account email is refused" do
+      @org.add_domain!("urjc.es")
+      prof = User.create!(email: "prof@urjc.es", name: "Prof", confirmed_at: nil)
+
+      assert_raises(VerificationEmailNotEligible) { @org.join_with_account_email!(prof) }
+    end
+
+    test "non-enrolled domain is refused" do
+      @org.add_domain!("urjc.es")
+      someone = User.create!(email: "x@gmail.com", confirmed_at: Time.current)
+
+      assert_raises(VerificationEmailNotEligible) { @org.join_with_account_email!(someone) }
+    end
+
+    test "config.trust_confirmed_account_email = false disables the shortcut" do
+      Organizations.configure { |c| c.trust_confirmed_account_email = false }
+      @org.add_domain!("urjc.es")
+      prof = User.create!(email: "prof@urjc.es", confirmed_at: Time.current)
+
+      assert_raises(VerificationEmailNotEligible) { @org.join_with_account_email!(prof) }
+    end
+
+    test "account email already claimed in the org is refused" do
+      @org.add_domain!("urjc.es")
+      first = User.create!(email: "prof@urjc.es", confirmed_at: Time.current)
+      @org.join_with_account_email!(first)
+
+      # A second account somehow presenting the same confirmed address
+      impostor = User.create!(email: "prof@urjc.es".upcase, confirmed_at: Time.current)
+      assert_raises(VerificationEmailAlreadyClaimed) { @org.join_with_account_email!(impostor) }
+    end
+
+    # =========================================================================
+    # accepts_join_requests?
+    # =========================================================================
+
+    test "accepts_join_requests? reflects available mechanisms" do
+      refute @org.accepts_join_requests?
+
+      domain = @org.add_domain!("inizio.com")
+      assert @org.accepts_join_requests?
+
+      domain.destroy!
+      code = @org.generate_join_code!
+      assert @org.accepts_join_requests?
+
+      code.revoke!
+      refute @org.accepts_join_requests?
+
+      @org.import_allowlist!(["ana@gmail.com"])
+      assert @org.accepts_join_requests?
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,9 @@ ActiveRecord::Schema.define do
   create_table :users, force: :cascade do |t|
     t.string :name
     t.string :email, null: false
+    # Devise-style confirmation timestamp — exercised by the
+    # join_with_account_email! trust shortcut (verified joining).
+    t.datetime :confirmed_at
     t.timestamps
   end
   add_index :users, :email, unique: true
@@ -54,11 +57,23 @@ ActiveRecord::Schema.define do
     t.references :organization, null: false, foreign_key: { to_table: :organizations_organizations }
     t.references :invited_by, null: true, foreign_key: { to_table: :users }
     t.string :role, null: false, default: "member"
-    t.text :metadata, default: "{}"
+    # json (not text) so Hash values round-trip — matches the jsonb/json
+    # columns the install migration creates in real apps.
+    t.json :metadata, default: {}
+    # Verified-joining provenance (v0.5.0)
+    t.string :joined_via
+    t.string :verified_email
+    t.string :verified_email_normalized
+    t.datetime :verified_at
     t.timestamps
   end
   add_index :organizations_memberships, [:user_id, :organization_id], unique: true
   add_index :organizations_memberships, :role
+  # One proven email => one membership per organization. NULLs never collide
+  # in unique indexes, so unverified memberships are unconstrained — same
+  # shape the install migration creates.
+  add_index :organizations_memberships, [:organization_id, :verified_email_normalized],
+            unique: true, name: "index_org_memberships_verified_email_unique"
 
   create_table :organizations_invitations, force: :cascade do |t|
     t.references :organization, null: false, foreign_key: { to_table: :organizations_organizations }
@@ -68,11 +83,83 @@ ActiveRecord::Schema.define do
     t.string :role, null: false, default: "member"
     t.datetime :accepted_at
     t.datetime :expires_at
+    t.json :metadata, default: {}
+    t.json :membership_metadata, default: {}
     t.timestamps
   end
   add_index :organizations_invitations, :token, unique: true
   add_index :organizations_invitations, :email
   add_index :organizations_invitations, [:organization_id, :email]
+
+  # === Verified joining (v0.5.0) ===
+
+  create_table :organizations_domains, force: :cascade do |t|
+    t.references :organization, null: false, foreign_key: { to_table: :organizations_organizations }
+    t.string :domain, null: false
+    t.json :membership_metadata, default: {}
+    t.json :metadata, default: {}
+    t.timestamps
+  end
+  add_index :organizations_domains, [:organization_id, :domain], unique: true
+  add_index :organizations_domains, :domain
+
+  create_table :organizations_join_codes, force: :cascade do |t|
+    t.references :organization, null: false, foreign_key: { to_table: :organizations_organizations }
+    t.string :code, null: false
+    t.string :label
+    t.boolean :requires_verified_domain_email, null: false, default: false
+    t.boolean :auto_approve, null: false, default: true
+    t.datetime :expires_at
+    t.integer :max_uses
+    t.integer :uses_count, null: false, default: 0
+    t.datetime :revoked_at
+    t.references :created_by, null: true, foreign_key: { to_table: :users }
+    t.json :membership_metadata, default: {}
+    t.json :metadata, default: {}
+    t.timestamps
+  end
+  add_index :organizations_join_codes, :code, unique: true
+
+  create_table :organizations_allowlist_entries, force: :cascade do |t|
+    t.references :organization, null: false, foreign_key: { to_table: :organizations_organizations }
+    t.string :email, null: false
+    t.string :email_normalized, null: false
+    t.string :source
+    t.json :membership_metadata, default: {}
+    t.datetime :claimed_at
+    t.references :claimed_by, null: true, foreign_key: { to_table: :users }
+    t.json :metadata, default: {}
+    t.timestamps
+  end
+  add_index :organizations_allowlist_entries, [:organization_id, :email_normalized], unique: true
+
+  create_table :organizations_join_requests, force: :cascade do |t|
+    t.references :organization, null: false, foreign_key: { to_table: :organizations_organizations }
+    t.references :user, null: false, foreign_key: true
+    t.string :status, null: false, default: "pending"
+    t.string :joined_via
+    t.references :join_code, null: true, foreign_key: { to_table: :organizations_join_codes }
+    t.string :message
+    t.string :verification_email
+    t.string :verification_email_normalized
+    t.string :verification_code_digest
+    t.datetime :verification_sent_at
+    t.datetime :verification_expires_at
+    t.integer :verification_attempts, null: false, default: 0
+    t.integer :verification_sends_count, null: false, default: 0
+    t.datetime :verified_at
+    t.references :decided_by, null: true, foreign_key: { to_table: :users }
+    t.datetime :decided_at
+    t.datetime :expires_at
+    t.json :metadata, default: {}
+    t.timestamps
+  end
+  add_index :organizations_join_requests, :status
+  ActiveRecord::Base.connection.execute(<<~SQL)
+    CREATE UNIQUE INDEX index_org_join_requests_pending_unique
+    ON organizations_join_requests (organization_id, user_id)
+    WHERE status = 'pending'
+  SQL
 end
 
 # Test User model with has_organizations
@@ -88,9 +175,11 @@ end
 GlobalID.app = "organizations-test"
 ActiveRecord::Base.include(GlobalID::Identification) unless ActiveRecord::Base.included_modules.include?(GlobalID::Identification)
 
-# Load engine mailer class for default invitation_mailer constantization.
+# Load engine mailer classes for default mailer constantization.
 mailer_path = File.expand_path("../app/mailers/organizations/invitation_mailer.rb", __dir__)
 require mailer_path if File.exist?(mailer_path)
+verification_mailer_path = File.expand_path("../app/mailers/organizations/verification_mailer.rb", __dir__)
+require verification_mailer_path if File.exist?(verification_mailer_path)
 
 # Require test helpers
 require "organizations/test_helpers"
@@ -113,6 +202,10 @@ module Organizations
     private
 
     def clean_database
+      Organizations::JoinRequest.delete_all
+      Organizations::AllowlistEntry.delete_all
+      Organizations::JoinCode.delete_all
+      Organizations::Domain.delete_all
       Organizations::Invitation.delete_all
       Organizations::Membership.delete_all
       Organizations::Organization.delete_all

--- a/test/verified_joining_config_test.rb
+++ b/test/verified_joining_config_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Organizations
+  class VerifiedJoiningConfigTest < Organizations::Test
+    # =========================================================================
+    # Defaults
+    # =========================================================================
+
+    test "verified-joining defaults" do
+      config = Organizations.configuration
+      assert_equal "Organizations::VerificationMailer", config.verification_mailer
+      assert_equal 15.minutes, config.verification_code_ttl
+      assert_equal 5, config.verification_max_attempts
+      assert_equal 60.seconds, config.verification_resend_interval
+      assert_equal 5, config.verification_max_sends
+      assert_nil config.verification_email_normalizer
+      assert_equal true, config.trust_confirmed_account_email
+      assert_equal 30.days, config.join_request_expiry
+      assert_nil config.join_code_generator
+    end
+
+    # =========================================================================
+    # Validation
+    # =========================================================================
+
+    test "verification_code_ttl must be a duration — codes must expire" do
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.verification_code_ttl = nil }
+      end
+    end
+
+    test "verification_resend_interval must be a duration" do
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.verification_resend_interval = "soon" }
+      end
+    end
+
+    test "verification_max_attempts must be a positive integer" do
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.verification_max_attempts = 0 }
+      end
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.verification_max_attempts = "five" }
+      end
+    end
+
+    test "verification_max_sends must be a positive integer" do
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.verification_max_sends = 0 }
+      end
+    end
+
+    test "verification_email_normalizer must be nil or callable" do
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.verification_email_normalizer = "downcase" }
+      end
+
+      Organizations.configure { |c| c.verification_email_normalizer = ->(e) { e.to_s.downcase } }
+      assert_equal "x@y.com", Organizations.configuration.normalize_verification_email("X@Y.COM")
+    end
+
+    test "trust_confirmed_account_email must be boolean" do
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.trust_confirmed_account_email = "yes" }
+      end
+    end
+
+    test "join_request_expiry accepts nil (never expire) and durations" do
+      Organizations.configure { |c| c.join_request_expiry = nil }
+      Organizations.configure { |c| c.join_request_expiry = 90.days }
+
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.join_request_expiry = "forever" }
+      end
+    end
+
+    test "join_code_generator must be nil or callable" do
+      assert_raises(ConfigurationError) do
+        Organizations.configure { |c| c.join_code_generator = "ABC" }
+      end
+    end
+
+    # =========================================================================
+    # normalize_verification_email plumbing
+    # =========================================================================
+
+    test "normalize_verification_email uses the default normalizer when unset" do
+      assert_equal "j.doe@inizio.com",
+                   Organizations.configuration.normalize_verification_email("J.Doe+x@INIZIO.COM.")
+    end
+  end
+end

--- a/test/verified_joining_config_test.rb
+++ b/test/verified_joining_config_test.rb
@@ -10,6 +10,7 @@ module Organizations
 
     test "verified-joining defaults" do
       config = Organizations.configuration
+
       assert_equal "Organizations::VerificationMailer", config.verification_mailer
       assert_equal 15.minutes, config.verification_code_ttl
       assert_equal 5, config.verification_max_attempts
@@ -58,6 +59,7 @@ module Organizations
       end
 
       Organizations.configure { |c| c.verification_email_normalizer = ->(e) { e.to_s.downcase } }
+
       assert_equal "x@y.com", Organizations.configuration.normalize_verification_email("X@Y.COM")
     end
 


### PR DESCRIPTION
# Verified Joining (v0.5.0): join requests, email domains, join codes, allowlists

Invitations cover **org→user**. This PR adds the **user→org** direction: people who claim to belong to an organization and need to *prove* it. It implements three items from the README roadmap (domain-based joining, request-to-join workflow, roster/bulk import) as one coherent feature set, fully additively — existing installs change nothing until they enroll a domain, generate a code, or import a roster.

> **Companion PR**: #18 repairs the RuboCop config (broken on modern RuboCop) and freezes pre-existing drift. The last commit here lints all new code against that repaired config; the two PRs merge independently in either order (CI runs `rake test` only).

## The four mechanisms

| Mechanism | Proof | Auto-member? |
|---|---|---|
| Request-to-join | a human approves (`approve_join_request!`) | on approval |
| Email domain | 6-digit code emailed to `anything@enrolled-domain.com` | on verify |
| Join code ("PIN") | possession of the code — optionally **+ domain email** (per-code flag) | per `auto_approve` |
| Allowlist / roster | 6-digit code emailed to a rostered address | on verify |

**The central idea: the proven email is decoupled from the account email.** A user signed up with a personal address can prove control of `j.doe@corp.com` and join Corp as a verified member. The proven address lands on the membership (`verified_email`) and is **unique per organization** — one inbox, one member. That single invariant is what makes self-serve joining fraud-resistant enough for real B2B programs.

## Design decisions (numbered for future reference)

1. **Memberships stay active-only.** All pending state lives on a new `JoinRequest` — the exact mirror of `Invitation` (both converge on `Membership`). Every existing invariant (counter cache, single-owner partial index, `[user, org]` uniqueness, `add_member!` semantics) is untouched, which is why this is safe for existing installs.
2. **Statuses stored vs derived**: `pending → approved | rejected | withdrawn` are stored; `:expired` is *derived* from a per-row `expires_at` stamped at creation from `config.join_request_expiry` — the exact pattern invitations already use (per-row snapshot, so changing config later never rewrites history). One open request per (org, user) via partial unique index (`WHERE status = 'pending'`); decided requests keep history without blocking a fresh request.
3. **Every self-serve join funnels through a `JoinRequest` row** — even instant code-joins and the confirmed-account-email shortcut create-and-auto-approve one. Uniform funnel = a complete, queryable audit trail of *how every member got in*, for free (`joined_via` ∈ `invited|code|domain_email|allowlist|manual`).
4. **The verified-email uniqueness is a plain composite unique index** on `(organization_id, verified_email_normalized)`, NOT a partial index: SQL NULLs never collide in unique indexes on PostgreSQL, SQLite, *and* MySQL, so unverified memberships are naturally unconstrained — identical semantics, zero adapter tricks.
5. **Codes are digests, never plaintext**: `SHA256(code + row_id)` (the row-id pepper makes identical codes on different requests produce different digests), constant-time compare, single-use (digest nulled on success), 15-min TTL, 5-attempt cap, resend throttles (60s interval, 5 sends/request). Plaintext exists only in the mailer delivery path.
6. **Wrong attempts survive the raise.** The failure is captured inside the row-locked transaction (which COMMITS the attempt increment) and raised *outside* it — raising inside would roll the increment back and hand attackers unlimited tries. This is the single most load-bearing subtlety in the PR; see `JoinRequest#verify_email_code!`.
7. **Auto-approval runs AFTER the enclosing transaction commits** (`JoinCode#redeem!`, challenge verify): `member_joined`/`join_request_approved` callbacks can never fire for a transaction that later rolls back. If approval fails, the pending request survives — a safe, resumable state.
8. **Domain matching is exact and evasion-hardened**: dot-boundary equality after normalization; `corp.com.evil.com`, `evilcorp.com`, multi-`@` shapes and trailing-dot FQDNs never match. Subdomains are deliberately separate domains — they routinely carry different member semantics (e.g. staff vs student subdomains), and each can carry different `membership_metadata`.
9. **Email normalization collapses case, whitespace, and `+tag` plus-addressing** (RFC 5233 subaddressing) — otherwise one inbox mints unlimited "distinct" identities against the uniqueness invariant. Gmail-style dot-collapsing is deliberately NOT applied (dots are significant in most corporate mail systems). Host-overridable: `config.verification_email_normalizer`.
10. **Rostered addresses still complete the inbox challenge** — a leaked roster CSV must grant nothing without inbox access. The entry is claimed (`claimed_at`/`claimed_by`) on join.
11. **`membership_metadata` copy-through**: domains, codes, allowlist entries, and invitations each carry a `membership_metadata` hash merged onto memberships they create (merge precedence when several instruments govern one join: domain < allowlist < join code — later wins). The gem never interprets the contents — it's the host's cohort/segmentation channel. Invitations also gained a plain `metadata` column (parity with every other table).
12. **Invitation acceptance now stamps provenance too**: accepting the emailed token proves the invited inbox → `joined_via: "invited"`, `verified_email` set — EXCEPT when `skip_email_validation` bypassed the email match with a different account email (no inbox proof → no stamp). If the address was already claimed in the org (recycled-address edge), the membership is still created, just unstamped — acceptance never breaks.
13. **`join_with_account_email!` trusts a CONFIRMED host account email** (`user.confirmed_at` present, Devise `:confirmable`-style) as inbox proof when its domain is enrolled — the zero-friction path. Gated by `config.trust_confirmed_account_email` (default true). Never trusts unconfirmed emails.
14. **`max_organizations` deliberately does NOT apply to joining** — that setting caps orgs a user can OWN (its historical semantics). Hosts wanting membership caps enforce them before calling approve/redeem (see "host responsibilities" below).
15. **Join codes are globally unique** (redemption needs no org context — QR/posters/links), generated from an ambiguity-free alphabet (no I/L/O/0/1), normalized on input (case/hyphens/spaces), displayed grouped (`7FHK-2MPX`). Uses are counted at **redemption** (a leaked code exhausts fast), with row-locked atomic accounting (two concurrent redemptions of a `max_uses: 1` code → exactly one success). Idempotent shapes documented in the follow-up comment.
16. **BYO-UI preserved**: models + APIs + one mailer, zero controllers/views/routes for joining. Hosts own the UI **and the rate limiting** of their join endpoints.

## Schema (all additive)

New tables: `organizations_domains`, `organizations_join_codes`, `organizations_allowlist_entries`, `organizations_join_requests` (columns in the diff; every table gets `metadata` + `membership_metadata` jsonb). Membership gains `joined_via`, `verified_email`, `verified_email_normalized`, `verified_at` + the uniqueness index. Invitations gain `metadata` + `membership_metadata`.

- Fresh installs: `rails g organizations:install` includes everything.
- Existing installs: **`rails g organizations:upgrade` + `rails db:migrate`** (new generator; reversible migration; PG/SQLite partial index for pending-request uniqueness, MySQL generated-column emulation — same trick as the invitations pending index; "other adapter" fallback to app-level validation).
- `test/dummy/db/schema.rb` updated for parity.

## API surface (complete)

```ruby
# Organization
org.add_domain!(domain, membership_metadata: {})
org.domains / org.join_codes / org.allowlist_entries / org.join_requests / org.pending_join_requests
org.generate_join_code!(label:, requires_verified_domain_email:, auto_approve:, expires_at:, max_uses:, created_by:, membership_metadata:)
org.import_allowlist!(emails, source:, membership_metadata: {})   # idempotent per address
org.approve_join_request!(req, approved_by:) / org.reject_join_request!(req, rejected_by:, reason:)
org.join_with_account_email!(user)
org.accepts_join_requests?     # true iff any live mechanism exists

# User (has_organizations)
user.request_to_join!(org, message: nil)   # idempotent; raises if already a member
user.pending_join_request_for(org)
user.organization_join_requests             # + nullify trails: decided_/created_/claimed_ associations

# JoinRequest
req.start_email_verification!(email:) / req.verify_email_code!(code)
req.approve!(decided_by:) / req.reject!(rejected_by:, reason:) / req.withdraw!
req.pending? / approved? / rejected? / withdrawn? / expired? / decided? / effective_status / email_verified?

# JoinCode
Organizations::JoinCode.redeem(code, user:)  # => Membership | JoinRequest
code.redeem!(user:) / code.revoke! / code.active? / code.status / code.display_code

# Membership
membership.verified? / joined_via / verified_email

# Config (defaults)
verification_mailer ("Organizations::VerificationMailer"), verification_code_ttl (15.minutes),
verification_max_attempts (5), verification_resend_interval (60.seconds), verification_max_sends (5),
verification_email_normalizer (nil ⇒ Organizations::EmailNormalizer), trust_confirmed_account_email (true),
join_request_expiry (30.days; nil = never), join_code_generator (nil ⇒ built-in 8-char)

# Callbacks (error-isolated, like all after-callbacks)
on_join_request_created   # ctx: organization, user, join_request
on_join_request_approved  # + membership, decided_by (nil = auto-approval)
on_join_request_rejected  # + decided_by
```

New error taxonomy (all under `Organizations::`): `JoinRequestError > {JoinRequestExpired, JoinRequestAlreadyDecided, VerificationError > {VerificationEmailNotEligible, VerificationEmailAlreadyClaimed, VerificationCodeInvalid, VerificationCodeExpired, VerificationAttemptsExceeded, VerificationThrottled}}`; `JoinCodeError > JoinCodeInvalid > JoinCodeExhausted` (Invalid deliberately covers unknown/revoked/expired — hosts should show one generic message and not leak which codes exist).

## ⚠️ Host responsibilities (READ before adopting)

1. **Rate-limit your join/redemption/verification endpoints.** The gem enforces per-request throttles (attempts, sends) but ships no controllers — IP/user-level rate limiting is yours.
2. **Enforce member caps BEFORE approve/redeem.** The `on_join_request_approved` callback is error-isolated (raising in it does NOT veto — unlike the strict `on_member_invited`); this is deliberate and documented in the initializer template.
3. Error copy for `VerificationEmailAlreadyClaimed` must not reveal WHO holds the address.

## Testing

- **1013 runs, 2230 assertions, 0 failures** (baseline was 877) on Ruby 3.4, and green under both `gemfiles/rails_7.2.gemfile` and `rails_8.1.gemfile` appraisals.
- New suites: `email_normalizer_test` (normalization + evasion shapes), `domain_test`, `allowlist_entry_test`, `join_code_test` (incl. deterministic race forms: `max_uses` exhaustion, no-double-consume idempotency), `join_request_test` (~50 cases: full challenge lifecycle, throttles, TTLs, attempt persistence, copy-through precedence, claimed-address race backstop, account-email shortcut), `invitation_provenance_test`, `verified_joining_config_test`.
- Race conditions are tested in **deterministic form** (create the conflicting row between check and act, assert graceful handling) because the test harness runs on a single in-memory SQLite connection — real-thread races can't be exercised there; the row-lock + unique-index backstops are the production guarantee.
- Test-harness notes: codes are made deterministic by stubbing `SecureRandom.random_number`; the harness `users` table gained `confirmed_at` to exercise the account-email shortcut; metadata columns in the harness schema use `t.json` so Hashes round-trip like the real jsonb/json columns.

## Deliberately NOT in this PR

- **No controllers/views/routes** for joining (BYO-UI).
- **No IP rate limiting** (host concern).
- **No SSO/SAML/SCIM** (a future gem-adjacent module at most; keeps this gem dependency-free).
- **No bulk token-invitations CSV** (the remaining roadmap item — `import_allowlist!` covers the roster use case; token-invite bulk mail is a different feature).
- **No IDN/punycode conversion** for domains (enroll punycode form; adding a `simpleidn` dep wasn't worth it — documented in `Domain#domain_shape`).

## Release checklist (for the maintainer)

- [ ] Merge #18 (config) and this PR (order irrelevant)
- [ ] `bundle install` on main to refresh `Gemfile.lock` for 0.5.0 (version.rb already bumped; CHANGELOG has the full entry)
- [ ] Tag + `gem push` (rubygems MFA)
- [ ] Bump the reference downstream apps (`~> 0.5.0`) — the SaaS host is the zero-config upgrade canary (expect zero behavioral diffs); the mobility host adopts the new APIs per its own `docs/organizations-prd.md`

Follow-up comments on this PR carry: (1) implementation nuances & invariants, (2) the edge-case ↔ test map, (3) the host integration guide, (4) known limitations & future work. **Everything a future maintainer needs is in this PR + those comments + the README chapter added in the diff.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S8paZHWL9y3BiPPqZp5ii
